### PR TITLE
Supports kubernetes pod and container for role member

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ K2HR3 REST API and K2HR3 API Server is the server side JavaScript program runnin
 [K2HR3 OpenStack Notification Listener Usage](https://k2hr3.antpick.ax/detail_osnl.html)  
 [K2HR3 Watcher Usage](https://k2hr3.antpick.ax/tools.html)  
 [K2HR3 Utilities for Setup](https://k2hr3.antpick.ax/setup.html)  
+[K2HR3 Demonstration](https://demo.k2hr3.antpick.ax/)
 
 [About k2hdkc](https://k2hdkc.antpick.ax/)  
 [About k2hash](https://k2hash.antpick.ax/)  
@@ -56,6 +57,7 @@ K2HR3 REST API and K2HR3 API Server is the server side JavaScript program runnin
 [K2HR3 REST API repository](https://github.com/yahoojapan/k2hr3_api)  
 [K2HR3 OpenStack Notification Listener](https://github.com/yahoojapan/k2hr3_osnl)  
 [K2HR3 Utilities](https://github.com/yahoojapan/k2hr3_utils)  
+[K2HR3 Container Registration Sidecar](https://github.com/yahoojapan/k2hr3_sidecar)  
 
 [k2hdkc](https://github.com/yahoojapan/k2hdkc)  
 [k2hash](https://github.com/yahoojapan/k2hash)  

--- a/config/k2hr3-init.sh.templ
+++ b/config/k2hr3-init.sh.templ
@@ -23,6 +23,8 @@ LOGFILE="/var/log/${SCRIPTNAME}.log"
 CLOUDINIT_DATA_DIR="/var/lib/cloud/data"
 INSTANCE_ID_FILE="${CLOUDINIT_DATA_DIR}/instance-id"
 K2HR3_ROLE_FILE="${CLOUDINIT_DATA_DIR}/k2hr3-role"
+K2HR3_CUK_FILE="${CLOUDINIT_DATA_DIR}/k2hr3-cuk"
+K2HR3_APIARG_FILE="${CLOUDINIT_DATA_DIR}/k2hr3-apiarg"
 
 K2HR3_USER_ROLE_TOKEN="{{= %K2HR3_ROLE_TOKEN% }}"
 K2HR3_API_HOST_URI="{{= %K2HR3_API_HOST_URI% }}/v1/role"
@@ -68,6 +70,32 @@ if [ $? -ne 0 ]; then
 	echo "`date "+%Y-%m-%d %H:%M:%S,%3N"` - ${SCRIPTNAME}[WARN]: Could not change mode for ${K2HR3_ROLE_FILE}, but continue..." | tee -a ${LOGFILE}
 fi
 echo "`date "+%Y-%m-%d %H:%M:%S,%3N"` - ${SCRIPTNAME}[INFO]: initialize host information for k2hr3" | tee -a ${LOGFILE}
+
+echo "${INSTANCE_ID}" > ${K2HR3_CUK_FILE}
+if [ $? -ne 0 ]; then
+	echo "`date "+%Y-%m-%d %H:%M:%S,%3N"` - ${SCRIPTNAME}[ERROR]: Could not put cuk=instanceid(${INSTANCE_ID}) to ${K2HR3_CUK_FILE}" | tee -a ${LOGFILE}
+	exit 1
+fi
+echo "`date "+%Y-%m-%d %H:%M:%S,%3N"` - ${SCRIPTNAME}[INFO]: Create cuk=instanceid(${INSTANCE_ID}) file(${K2HR3_CUK_FILE})" | tee -a ${LOGFILE}
+
+chmod 444 ${K2HR3_CUK_FILE}
+if [ $? -ne 0 ]; then
+	echo "`date "+%Y-%m-%d %H:%M:%S,%3N"` - ${SCRIPTNAME}[WARN]: Could not change mode for ${K2HR3_CUK_FILE}, but continue..." | tee -a ${LOGFILE}
+fi
+echo "`date "+%Y-%m-%d %H:%M:%S,%3N"` - ${SCRIPTNAME}[INFO]: initialize cuk(instanceid) information for k2hr3" | tee -a ${LOGFILE}
+
+echo "${CUK_PARAMETER}" > ${K2HR3_APIARG_FILE}
+if [ $? -ne 0 ]; then
+	echo "`date "+%Y-%m-%d %H:%M:%S,%3N"` - ${SCRIPTNAME}[ERROR]: Could not put api url argument(${CUK_PARAMETER}) to ${K2HR3_APIARG_FILE}" | tee -a ${LOGFILE}
+	exit 1
+fi
+echo "`date "+%Y-%m-%d %H:%M:%S,%3N"` - ${SCRIPTNAME}[INFO]: Create api url argument(${CUK_PARAMETER}) file(${K2HR3_APIARG_FILE})" | tee -a ${LOGFILE}
+
+chmod 444 ${K2HR3_APIARG_FILE}
+if [ $? -ne 0 ]; then
+	echo "`date "+%Y-%m-%d %H:%M:%S,%3N"` - ${SCRIPTNAME}[WARN]: Could not change mode for ${K2HR3_APIARG_FILE}, but continue..." | tee -a ${LOGFILE}
+fi
+echo "`date "+%Y-%m-%d %H:%M:%S,%3N"` - ${SCRIPTNAME}[INFO]: initialize cuk information for k2hr3" | tee -a ${LOGFILE}
 
 exit 0
 

--- a/lib/basicipcheck.js
+++ b/lib/basicipcheck.js
@@ -34,7 +34,7 @@ var r3logger	= require('./dbglogging');
 //---------------------------------------------------------
 // ipdata:		IP address information
 //				{
-//					ipaddr:	ip,			-> ip address string
+//					ip:		ip,			-> ip address string
 //					cuk:	cuk,		-> cuk string					(not use)
 //					port:	port,		-> port number or *				(not use)
 //					extra:	string		-> 'openstack-auto-v1' or etc	(not use)
@@ -58,8 +58,8 @@ function checkAddressAliveByPing(ipdata, chkipconfig, callback)
 		_callback(new Error('IP data is wrong : ' + JSON.stringify(_ipdata)), _ipdata);
 		return;
 	}
-	if(!apiutil.isSafeString(_ipdata.ipaddr)){
-		_callback(new Error('IP Address is wrong : ' + JSON.stringify(_ipdata.ipaddr)), _ipdata);
+	if(!apiutil.isSafeString(_ipdata.ip)){
+		_callback(new Error('IP Address is wrong : ' + JSON.stringify(_ipdata.ip)), _ipdata);
 		return;
 	}
 	if(!apiutil.isSafeEntity(_chkipconfig)){				// already check this...
@@ -76,7 +76,7 @@ function checkAddressAliveByPing(ipdata, chkipconfig, callback)
 	//
 	var	_timeoutsec	 = (_timeoutms / 1000) + 1;
 
-	if(-1 == _ipdata.ipaddr.indexOf(':')){
+	if(-1 == _ipdata.ip.indexOf(':')){
 		_command = _chkipconfig.command4;
 	}else{
 		_command = _chkipconfig.command6;
@@ -84,12 +84,12 @@ function checkAddressAliveByPing(ipdata, chkipconfig, callback)
 	_command += ' ' + apiutil.getSafeString(_chkipconfig.params);
 	_command += ' ' + apiutil.getSafeString(_chkipconfig.timeoutparam);
 	_command += ' ' + _timeoutsec.toString();
-	_command += ' ' + _ipdata.ipaddr;
+	_command += ' ' + _ipdata.ip;
 
 	childProcess.exec(_command, function(error, stdout, stderr)			// eslint-disable-line no-unused-vars
 	{
 		if(error){
-			r3logger.dlog('Something error occurred pinging to ' + _ipdata.ipaddr + ' by : ' + JSON.stringify(error));
+			r3logger.dlog('Something error occurred pinging to ' + _ipdata.ip + ' by : ' + JSON.stringify(error));
 			_callback(error, _ipdata);
 		}else{
 			_callback(null, _ipdata);
@@ -102,7 +102,7 @@ function checkAddressAliveByPing(ipdata, chkipconfig, callback)
 //---------------------------------------------------------
 // ipdata:		IP address information
 //				{
-//					ipaddr:	ip,			-> ip address string
+//					ip:		ip,			-> ip address string
 //					cuk:	cuk,		-> cuk string					(not use)
 //					port:	port,		-> port number or *				(not use)
 //					extra:	string		-> 'openstack-auto-v1' or etc	(not use)
@@ -126,8 +126,8 @@ function checkAddressAlive(ipdata, chkipconfig, callback)
 		_callback(new Error('IP data is wrong : ' + JSON.stringify(_ipdata)), _ipdata);
 		return;
 	}
-	if(!apiutil.isSafeString(_ipdata.ipaddr)){
-		_callback(new Error('IP Address is wrong : ' + JSON.stringify(_ipdata.ipaddr)), _ipdata);
+	if(!apiutil.isSafeString(_ipdata.ip)){
+		_callback(new Error('IP Address is wrong : ' + JSON.stringify(_ipdata.ip)), _ipdata);
 		return;
 	}
 	if(!apiutil.isSafeEntity(_chkipconfig)){				// already check this...
@@ -152,7 +152,7 @@ function checkAddressAlive(ipdata, chkipconfig, callback)
 	// checking DNS with timeout by set timer
 	//
 	try{
-		dns.reverse(_ipdata.ipaddr, function(error, hostnames)
+		dns.reverse(_ipdata.ip, function(error, hostnames)
 		{
 			if(error){
 				r3logger.dlog('Something error occurred in dns lookup by error: ' + JSON.stringify(error));
@@ -165,7 +165,7 @@ function checkAddressAlive(ipdata, chkipconfig, callback)
 				}
 				return;
 			}
-			r3logger.dlog('Success dns lookup for ip address(' + _ipdata.ipaddr + ') to hostnames(' + JSON.stringify(hostnames) + ').');
+			r3logger.dlog('Success dns lookup for ip address(' + _ipdata.ip + ') to hostnames(' + JSON.stringify(hostnames) + ').');
 
 			if(_is_and){
 				// [Type = AND] DNS is success, then this IP is alive
@@ -193,7 +193,7 @@ function checkAddressAlive(ipdata, chkipconfig, callback)
 //---------------------------------------------------------
 // ipdatas:		IP address information array
 //				[{
-//					ipaddr:			<string>,			-> ip address string
+//					ip:				<string>,			-> ip address string
 //					cuk:			<string>,			-> cuk string								(not use)
 //					port:			<number or *>,		-> port number or *							(not use)
 //					extra:			<string>,			-> 'openstack-auto-v1' or etc				(not use)
@@ -255,10 +255,10 @@ function checkAddressesAliveParallel(ipdatas, start, chkipconfig, callback)
 		checkAddressAlive(_ipdatas[_start + cnt], _chkipconfig, function(error, ipdata)
 		{
 			if(error){
-				r3logger.dlog('IP Address(' + ipdata.ipaddr + ') : CUK(' + ipdata.cuk + ') is not alive by ' + JSON.stringify(error));
+				r3logger.dlog('IP Address(' + ipdata.ip + ') : CUK(' + ipdata.cuk + ') is not alive by ' + JSON.stringify(error));
 				ipdata.alive = false;
 			}else{
-				r3logger.dlog('IP Address(' + ipdata.ipaddr + ') : CUK(' + ipdata.cuk + ') is alive');
+				r3logger.dlog('IP Address(' + ipdata.ip + ') : CUK(' + ipdata.cuk + ') is alive');
 				ipdata.alive = true;
 			}
 			++setcnt;
@@ -278,7 +278,7 @@ function checkAddressesAliveParallel(ipdatas, start, chkipconfig, callback)
 //---------------------------------------------------------
 // ipdatas:		IP address information array
 //				[{
-//					ipaddr:			<string>,			-> ip address string
+//					ip:				<string>,			-> ip address string
 //					cuk:			<string>,			-> cuk string								(not use)
 //					port:			<number or *>,		-> port number or *							(not use)
 //					extra:			<string>,			-> 'openstack-auto-v1' or etc				(not use)

--- a/lib/dummyuserapi.js
+++ b/lib/dummyuserapi.js
@@ -98,6 +98,7 @@ var dummyapi_ep = function()
 //						"Token Id" = "(<base id(64bit:8byte)> ^ <crypt id(64bit:8byte)>)" + "(<userex id(64bit:8byte)> ^ <crypt id(64bit:8byte)>)"
 // User Token Key:		"yrn:yahoo::::token:user/<Token Id>"
 // User Token Seed:		{
+//							publisher:	"DUMMYUSERAPI"
 //							userexid:	"user extra id(user generated extra id)"
 //							date:		"UTC time at create"
 //							expire:		"UTC time at expire"
@@ -107,6 +108,8 @@ var dummyapi_ep = function()
 //							ip:			always null
 //							hostname:	always null
 //							port:		always 0
+//							cuk:		always null
+//							extra:		always null
 //							tenant:		if scoped token, this is "tenant name". if not, this is null
 //							verify:		"random 64bit id for verify token"
 //						}
@@ -135,26 +138,28 @@ var dummyapi_ep = function()
 //						token:		undefined(error) or user token string
 //						expire_at:	expire date(UTC ISO 8601)
 //						token_seed:	JSON token seed data
-//						userid:		(if need_userid is true, this value is set userid)
+//						userid:		set userid
 // 					}
 // 
 // [NOTE]
 // user token seed value is following
 // 					{
-//						userexid:	"user extra id(user generated extra id)"
+//						publisher:	"DUMMYUSERAPI"
+//						userexid:	"user extra id(a part of seed uuid4)"
 //						date:		"UTC ISO 8601 time at create"
 //						expire:		"UTC ISO 8601 time at expire"
 //						creator:	"User full yrn"
-//						base:		"generated 64bit random binary"
+//						base:		"32byte hex string"
 //						user:		"user name"
 //						ip:			always null
 //						hostname:	always null
 //						port:		always 0
+//						cuk:		always null
+//						extra:		always null
 //						tenant:		if scoped token, this is "tenant name". if not, this is null
-//						verify:		"random 64bit id for verify token"
 //					}
 // 
-function rawCreateUserTokenByDummyUser(user, tenant, need_userid)
+function rawCreateUserTokenByDummyUser(user, tenant)
 {
 	var	resobj = {result: true, message: null};
 
@@ -167,9 +172,6 @@ function rawCreateUserTokenByDummyUser(user, tenant, need_userid)
 	if(!apiutil.isSafeString(tenant)){
 		tenant = null;
 	}
-	if(!apiutil.isSafeEntity(need_userid) || 'boolean' !== typeof need_userid){
-		need_userid = false;
-	}
 
 	var	dkcobj			= k2hr3.getK2hdkc(true, false);										// use permanent object(need to clean)
 	user				= user.toLowerCase();
@@ -181,33 +183,31 @@ function rawCreateUserTokenByDummyUser(user, tenant, need_userid)
 		return resobj;
 	}
 
-	// convert user id to 64 bit binary array
-	var	userid			= String(apiutil.getUnixtime());									// Dummy user id(= unix time)
-	var	user_ex_id		= apiutil.convertStringToBin64(userid);
-	if(apiutil.isEmptyArray(user_ex_id) || 4 !== user_ex_id.length){
-		resobj.result	= false;
-		resobj.message	= 'Failed to convert user id for user(' + user + ') to 64bit binary array.';
-		r3logger.elog(resobj.message);
-		dkcobj.clean();
-		return resobj;
+	// check user id exists.
+	var	userid = dkcobj.getValue(keys.USER_ID_KEY, null, true, null);						// yrn:yahoo::::user:<user>:id
+	if(!apiutil.isSafeString(userid)){
+		// make dummy user id
+		userid = apiutil.getStrUuid4();														// Dummy user id(uuid4)
 	}
-	var	hibit_user_ex = apiutil.getRandomBin64();											// random value for higher 32bit value
-	user_ex_id[0] = hibit_user_ex[0];														// over write
-	user_ex_id[1] = hibit_user_ex[1];
+
+	// user seed id(generated every time)
+	var	user_ex_id	= apiutil.getStrUuid4();												// seed(uuid4)
 
 	// make token seed value
 	var	expire_limit	= 24 * 60 * 60;														// default 24H expire for dummy user
 	var	now_unixtime	= apiutil.getUnixtime();
 	var	token_seed		= {};
-	token_seed.userexid	= user_ex_id;														// user extra id based dummy user id
+	token_seed.publisher= 'DUMMYUSERAPI';													// "DUMMYUSERAPI"
+	token_seed.userexid	= user_ex_id;														// seed(uuid4)
 	token_seed.date		= (new Date(now_unixtime * 1000)).toISOString();					// now date(UTC ISO 8601)
 	token_seed.expire	= (new Date((now_unixtime + expire_limit) * 1000)).toISOString();	// expire date(UTC ISO 8601)
 	token_seed.creator	= keys.USER_KEY;													// "yrn:yahoo::::user:<user>"
-	token_seed.base		= apiutil.getRandomBin64();											// base id(random)
 	token_seed.user		= user;																// user(creator)
 	token_seed.hostname= null;																// hostname(creator)
 	token_seed.ip		= null;																// ip(creator)
 	token_seed.port		= 0;																// port(creator)
+	token_seed.cuk		= null;																// cuk(creator)
+	token_seed.extra	= null;																// extra(creator)
 	token_seed.tenant	= tenant;															// tenant(if scope, not null)
 
 	// user token and yrn key
@@ -216,14 +216,17 @@ function rawCreateUserTokenByDummyUser(user, tenant, need_userid)
 
 	// create key
 	for(var is_loop = true; is_loop; ){														// for eslint
-		// set verify value
-		token_seed.verify	= apiutil.getRandomBin64();										// random value
-
 		// make user token
-		var	hiBinToken		= apiutil.makeXorValue(token_seed.base, token_seed.verify);
-		var	lowBinToken		= apiutil.makeXorValue(token_seed.userexid, token_seed.verify);
-		user_token			= apiutil.convertBin64ToHexString(hiBinToken);
-		user_token			+= apiutil.convertBin64ToHexString(lowBinToken);
+		var	token_elements	= apiutil.makeStringToken256(user_ex_id, userid);
+		if(!apiutil.isSafeEntity(token_elements)){
+			resobj.result	= false;
+			resobj.message	= 'could not make token from ' + JSON.stringify(user_ex_id) + ' and ' + JSON.stringify(userid);
+			r3logger.elog(resobj.message);
+			dkcobj.clean();
+			return resobj;
+		}
+		user_token			= token_elements.str_token;
+		token_seed.base		= token_elements.str_base;										// token base
 
 		// user token key
 		token_user_key		= keys.TOKEN_USER_TOP_KEY + '/' + user_token;					// "yrn:yahoo::::token:user/<user token>"
@@ -241,11 +244,48 @@ function rawCreateUserTokenByDummyUser(user, tenant, need_userid)
 	resobj.token		= user_token;
 	resobj.expire_at	= token_seed.expire;
 	resobj.token_seed	= JSON.stringify(token_seed);
-	if(need_userid){
-		resobj.userid	= userid;
-	}
+	resobj.userid		= userid;
 
 	dkcobj.clean();
+	return resobj;
+}
+
+//---------------------------------------------------------
+// Verify User Token Publisher For dummy user
+//---------------------------------------------------------
+// 
+// token_seed		:	token seed data
+//
+// result			:	{
+//							result:		true/false
+//							message:	null or error message string
+// 						}
+// 
+function rawVerifyUserTokenPublisherByDummyUser(token_seed)
+{
+	var	resobj = {result: true, message: null};
+
+	if(!apiutil.isSafeString(token_seed)){
+		resobj.result	= false;
+		resobj.message	= 'token_seed(not printable) is not safe entity.';
+		r3logger.elog(resobj.message);
+		return resobj;
+	}
+
+	// parse seed
+	var	seed = token_seed;
+	if(apiutil.checkSimpleJSON(token_seed)){
+		seed = JSON.parse(token_seed);
+	}
+	if(	!apiutil.isSafeEntity(seed)				||
+		!apiutil.isSafeString(seed.publisher)	||
+		(seed.publisher != 'DUMMYUSERAPI')		)		// publisher must be 'DUMMYUSERAPI'
+	{
+		resobj.result	= false;
+		resobj.message	= 'token_seed(not printable) is not safe entity.';
+		r3logger.elog(resobj.message);
+		return resobj;
+	}
 	return resobj;
 }
 
@@ -253,17 +293,18 @@ function rawCreateUserTokenByDummyUser(user, tenant, need_userid)
 // Verify User Token From dummy user
 //---------------------------------------------------------
 // 
-// user			:	target user name for token
-// tenant		:	target tenant name for token(if token is scoped)
-// token		:	check token
-// token_seed	:	token seed data
+// dkcobj_permanent	:	dkcobj object
+// user				:	target user name for token
+// tenant			:	target tenant name for token(if token is scoped)
+// token			:	check token
+// token_seed		:	token seed data
 //
-// result		:	{
-//						result:		true/false
-//						message:	null or error message string
-// 					}
+// result			:	{
+//							result:		true/false
+//							message:	null or error message string
+// 						}
 // 
-function rawVerifyUserTokenByDummyUser(user, tenant, token, token_seed)
+function rawVerifyUserTokenByDummyUser(dkcobj_permanent, user, tenant, token, token_seed)
 {
 	var	resobj = {result: true, message: null};
 
@@ -279,18 +320,17 @@ function rawVerifyUserTokenByDummyUser(user, tenant, token, token_seed)
 	if(apiutil.checkSimpleJSON(token_seed)){
 		seed = JSON.parse(token_seed);
 	}
-	if(	!apiutil.isSafeEntity(seed)			||
-		apiutil.isEmptyArray(seed.userexid)	||
-		4 !== seed.userexid.length			||
-		!apiutil.isSafeString(seed.date)	||
-		!apiutil.isSafeString(seed.expire)	||
-		!apiutil.isSafeString(seed.creator)	||
-		apiutil.isEmptyArray(seed.base)		||
-		4 !== seed.base.length				||
-		!apiutil.isSafeString(seed.user)	||
-		!apiutil.compareCaseString(seed.user, user)	||
-		apiutil.isEmptyArray(seed.verify)	||
-		4 !== seed.verify.length			)
+
+	if(	!apiutil.isSafeEntity(seed)				||
+		!apiutil.isSafeString(seed.publisher)	||
+		(seed.publisher != 'DUMMYUSERAPI')		||		// publisher must be 'DUMMYUSERAPI'
+		!apiutil.isSafeString(seed.userexid)	||
+		!apiutil.isSafeString(seed.date)		||
+		!apiutil.isSafeString(seed.expire)		||
+		!apiutil.isSafeString(seed.creator)		||
+		!apiutil.isSafeString(seed.base)		||
+		!apiutil.isSafeString(seed.user)		||
+		!apiutil.compareCaseString(seed.user, user))
 	{
 		resobj.result	= false;
 		resobj.message	= 'token_seed(not printable) is not safe entity.';
@@ -314,19 +354,46 @@ function rawVerifyUserTokenByDummyUser(user, tenant, token, token_seed)
 		return resobj;
 	}
 
-	// calculate token
-	var	hiBinToken		= apiutil.makeXorValue(seed.base, seed.verify);
-	var	lowBinToken		= apiutil.makeXorValue(seed.userexid, seed.verify);
-	var	cal_token		= apiutil.convertBin64ToHexString(hiBinToken);
-	cal_token			+= apiutil.convertBin64ToHexString(lowBinToken);
+	// k2hdkc
+	var	keys	= r3keys(seed.user, seed.tenant);
+	var	dkcobj	= dkcobj_permanent;
+	if(!apiutil.isSafeEntity(dkcobj)){
+		dkcobj	= k2hr3.getK2hdkc(true, false);												// use permanent object(need to clean)
+		if(!apiutil.isSafeEntity(dkcobj)){
+			resobj.result	= false;
+			resobj.message	= 'Not initialize yet.';
+			r3logger.elog(resobj.message);
+			return resobj;
+		}
+	}
 
-	// verify
-	if(token !== cal_token){
+	// get user id
+	var	userid	= dkcobj.getValue(keys.USER_ID_KEY, null, true, null);						// get user id from "yrn:yahoo::::user:<user>:id"
+	if(!apiutil.isSafeEntity(dkcobj_permanent)){
+		dkcobj.clean();
+	}
+	if(!apiutil.isSafeString(userid)){
 		resobj.result	= false;
-		resobj.message	= 'token(' + token + ') and token_seed(not printable) are not matched.';
+		resobj.message	= 'could not get user id for user(' + seed.user + ').';
 		r3logger.elog(resobj.message);
 		return resobj;
 	}
+
+	// make verify token
+	var	token_elements	= apiutil.makeStringToken256(seed.userexid, userid, seed.base);
+	if(!apiutil.isSafeEntity(token_elements)){
+		resobj.result	= false;
+		resobj.message	= 'could not make verify token from ' + JSON.stringify(seed.userexid) + ' and ' + JSON.stringify(userid) + ' and ' + JSON.stringify(seed.base);
+		r3logger.elog(resobj.message);
+		return resobj;
+	}
+	if(token !== token_elements.str_token){
+		resobj.result	= false;
+		resobj.message	= 'token(' + token + ') verify is failure, verify token is ' + token_elements.str_token + '.';
+		r3logger.elog(resobj.message);
+		return resobj;
+	}
+
 	return resobj;
 }
 
@@ -400,7 +467,7 @@ function rawGetUserTenantInfoFromToken(token)
 	}
 
 	// verify token
-	var	vres = rawVerifyUserTokenByDummyUser(token_user, token_tenant, token, token_seed);
+	var	vres = rawVerifyUserTokenByDummyUser(dkcobj, token_user, token_tenant, token, token_seed);
 	if(!vres.result){
 		resobj.result	= false;
 		resobj.message	= 'failed to verify token(' + token + ') with seed by ' + vres.message;
@@ -412,7 +479,7 @@ function rawGetUserTenantInfoFromToken(token)
 	// get user id
 	keys		= r3keys(token_user, null);													// remake keys
 	var	userid	= dkcobj.getValue(keys.USER_ID_KEY, null, true, null);						// get user id from "yrn:yahoo::::user:<user>:id"
-	if(!apiutil.isSafeStrings(userid)){
+	if(!apiutil.isSafeString(userid)){
 		resobj.result	= false;
 		resobj.message	= 'could not get user id for user(' + token_user + ').';
 		r3logger.elog(resobj.message);
@@ -461,7 +528,7 @@ function rawGetUserUnscopedTokenDummy(uname, callback)
 	//
 	// Create unscoped user token
 	//
-	var	resobj = rawCreateUserTokenByDummyUser(uname, null, true);				// not specify expire limit now(using default).
+	var	resobj = rawCreateUserTokenByDummyUser(uname, null);					// not specify expire limit now(using default).
 	if(!resobj.result){
 		error = new Error('could not create user token for uname(' + uname + ') or something wrong result : ' + resobj.message);
 		r3logger.elog(error.message);
@@ -529,7 +596,7 @@ function rawGetUserScopedTokenDummy(token, tenant, callback)
 	}
 
 	// create scoped token
-	var	resobj = rawCreateUserTokenByDummyUser(token_info.user, tenant, false);					// not specify expire limit now(using default).
+	var	resobj = rawCreateUserTokenByDummyUser(token_info.user, tenant);						// not specify expire limit now(using default).
 	if(!resobj.result){
 		error = new Error('could not create user scoped token for uname(' + token_info.user + ')/user id(' + token_info.userid + ') for tenant(' + tenant + ').');
 		r3logger.elog(error.message);
@@ -658,9 +725,17 @@ exports.getUserScopedToken = function(unscopedtoken, tenantname, tenantid, callb
 	return rawGetUserScopedTokenDummy(unscopedtoken, tenantname, callback);
 };
 
+//
+// Verify seed publisher type
+//
+exports.verifyUserTokenPublisher = function(token_seed)
+{
+	return rawVerifyUserTokenPublisherByDummyUser(token_seed);
+};
+
 exports.verifyUserToken = function(user, tenant, token, token_seed)
 {
-	return rawVerifyUserTokenByDummyUser(user, tenant, token, token_seed);
+	return rawVerifyUserTokenByDummyUser(null, user, tenant, token, token_seed);
 };
 
 //

--- a/lib/ipwatch.js
+++ b/lib/ipwatch.js
@@ -183,7 +183,7 @@ function rawWatchAddressesAliveEx(ipchecker, callback)
 	//
 	// make ip addresses list depending cuk
 	//
-	var	targetres = k2hr3.getAllIpDatasByCuk();
+	var	targetres = k2hr3.getAllIpDatasByCuk(true);															// Currently supports only openstack
 	if(!apiutil.isSafeEntity(targetres) && apiutil.isSafeEntity(targetres.error)){
 		_callback(false, new Error('failed getting IP addresses list depending cuk by ' + JSON.stringify(targetres.error)));
 		return;

--- a/lib/k2hr3apiutil.js
+++ b/lib/k2hr3apiutil.js
@@ -20,9 +20,10 @@
 
 'use strict';
 
-var dns	= require('dns');
-var url	= require('url');
-var	fs	= require('fs');
+var dns		= require('dns');
+var url		= require('url');
+var	fs		= require('fs');
+var crypto	= require('crypto');
 
 //---------------------------------------------------------
 // Utilities for variables
@@ -102,11 +103,23 @@ function rawCheckSimpleJSON(str)
 		return false;
 	}
 	try{
-		var tmpstr = JSON.parse(str);					// eslint-disable-line no-unused-vars
+		var tmp = JSON.parse(str);						// eslint-disable-line no-unused-vars
 	}catch(exception){
 		return false;
 	}
 	return true;
+}
+
+function rawParseJSON(str)
+{
+	if(undefined === str || null === str || !isNaN(str) || 'string' !== typeof str){
+		return null;
+	}
+	try{
+		return JSON.parse(str);
+	}catch(exception){
+		return null;
+	}
 }
 
 function rawIsArray(arr)
@@ -316,6 +329,28 @@ function convertUnixtime(base)
 		unixtime_ms	= Date.parse(base);
 	}
 	return Math.floor(unixtime_ms / 1000);
+}
+
+function rawConvertISOStringToUnixtime(iso)
+{
+	if(!rawIsSafeString(iso)){
+		return 0;
+	}
+	var	isoTime	= new Date(iso);
+	var	utime	= isoTime.getTime() / 1000;
+	return utime;
+}
+
+function rawGetExpireUnixtime(starttime, expiretime)
+{
+	return (expiretime - starttime);
+}
+
+function rawGetExpireUnixtimeFromISOStrings(startiso, expireiso)
+{
+	var	starttime	= rawConvertISOStringToUnixtime(startiso);
+	var	expiretime	= rawConvertISOStringToUnixtime(expireiso);
+	return rawGetExpireUnixtime(starttime, expiretime);
 }
 
 //---------------------------------------------------------
@@ -648,165 +683,244 @@ function rawGetNormalizeParameter(parameter, regex_ptn, pattern)
 }
 
 //---------------------------------------------------------
-// Utilities for binary and string
+// Utilities for UUID4
 //---------------------------------------------------------
+// RFC4122
+// https://www.ietf.org/rfc/rfc4122.txt
 //
-// Get 64bit random value
+// UUID4 = xxxxxxxx-xxxx-Nxxx-Mxxx-xxxxxxxxxxxx
+//			N: 0x4X
+//			M: 0x{8,9,A,B}X
 //
-// Return value is array(4) which has four value.
-//	[
-//		value[0]...	BE: 0 -15
-//		value[1]...	BE: 16-31
-//		value[2]...	BE: 32-47
-//		value[3]...	BE: 48-63
-//	]
-//
-function rawGetRandomBin64()
+function rawGetBinUuid4()
 {
-	var	value	= new Array(4);
-	value[0]	= Math.floor(Math.random() * 10000000000000000) & 0xffff;
-	value[1]	= Math.floor(Math.random() * 10000000000000000) & 0xffff;
-	value[2]	= Math.floor(Math.random() * 10000000000000000) & 0xffff;
-	value[3]	= Math.floor(Math.random() * 10000000000000000) & 0xffff;
-	return value;
+	var binUuid4= crypto.randomBytes(16);
+	binUuid4[6]	= (binUuid4[6] & 0x0f) | 0x40;	// UUID4 must be 0x4X for pos 6 in buffer
+	binUuid4[8]	= (binUuid4[8] & 0x3f) | 0x80;	// UUID4 must be 0x{8,9,A,B}X for pos 8 in buffer
+
+	return binUuid4;
+}
+
+// [NOTE]
+// If binary data is given, this is only a conversion to UUID format,
+// not a method that enforces UUID4 format.
+//
+function rawGetStrUuid4(binUuid4)
+{
+	if(!rawIsSafeEntity(binUuid4) || !(binUuid4 instanceof Buffer)){
+		binUuid4 = rawGetBinUuid4();
+	}
+	var	parsed	= binUuid4.toString('hex').match(/(.{8})(.{4})(.{4})(.{4})(.{12})/);
+	parsed.shift();								// first element is all, then skip it.
+	var	strUuid	= parsed.join('-');
+	return strUuid;
+}
+
+function rawIsSafeStrUuid4(strUuid4)
+{
+	if(!rawIsSafeString(strUuid4)){
+		return false;
+	}
+	// split '-' separator
+	var	strArray = strUuid4.split('-');
+	if(5 != strArray.length){
+		return false;
+	}
+	// check length
+	if(	0 == strArray[0].length || 8 < strArray[0].length	||
+		0 == strArray[1].length || 4 < strArray[1].length	||
+		0 == strArray[2].length || 4 < strArray[2].length	||
+		0 == strArray[3].length || 4 < strArray[3].length	||
+		0 == strArray[4].length || 12 < strArray[4].length	)
+	{
+		return false;
+	}
+	return true;
+}
+
+function rawCvtStrToBinUuid4(strUuid4)
+{
+	if(!rawIsSafeString(strUuid4)){
+		return null;
+	}
+	// split '-' separator
+	var	strArray = strUuid4.split('-');
+	if(5 != strArray.length){
+		return null;
+	}
+	// check length and fill '0' for short part
+	strArray[0] = rawFillZeroString(strArray[0], 8);
+	strArray[1] = rawFillZeroString(strArray[1], 4);
+	strArray[2] = rawFillZeroString(strArray[2], 4);
+	strArray[3] = rawFillZeroString(strArray[3], 4);
+	strArray[4] = rawFillZeroString(strArray[4], 12);
+	if(null == strArray[0] || null == strArray[1] || null == strArray[2] || null == strArray[3] || null == strArray[4]){
+		return null;
+	}
+	// uuid full hex string
+	var	fullString = strArray.join('');
+
+	// convert to binary array
+	var	binUuid4 = new Uint8Array(fullString.match(/.{1,2}/g).map(function(val){ return parseInt(val, 16); }));
+	return Buffer(binUuid4);
+}
+
+function rawFillZeroString(str, size)
+{
+	if(!rawIsSafeString(str)){
+		return null;
+	}
+	if(size < str.length){
+		return null;
+	}else if(str.length < size){
+		var	fillstr = '';
+		for(var	fillcnt = size - str.length; 0 < fillcnt; --fillcnt){
+			fillstr += '0';
+		}
+		str = fillstr + str;
+	}
+	return str;
 }
 
 //
-// Convert 64bit value array to hex string
+// Return result
+// {
+//		hi_id:		Buffer[16] for hi uuid
+//		low_id:		Buffer[16] for low uuid
+//		base:		Buffer[32] for base
+//		str_token:	hex[32] string for token
+//		token:		Buffer[32] for token
+// }
 //
-// Input value is array(4) which has four value.
-//
-function rawConvertBin64ToHexString(value)
+function rawMakeToken256(hiUuid4, lowUuid4, base)
 {
-	if(rawIsEmptyArray(value) || value.length < 4){
-		return '';
+	// hiUuid4[128] / lowUuid4[128]
+	if(	!rawIsSafeEntity(hiUuid4)  || !(hiUuid4 instanceof Buffer)  || 16 != hiUuid4.length  ||
+		!rawIsSafeEntity(lowUuid4) || !(lowUuid4 instanceof Buffer) || 16 != lowUuid4.length ||
+		!rawIsSafeEntity(base)     || !(base instanceof Buffer)     || 32 != base.length     )
+	{
+		return null;
 	}
-	var	result = '';
-	for(var cnt = 0; cnt < 4; ++cnt){
-		var	strtmp = value[cnt].toString(16);
-		while(0 !== cnt && strtmp.length < 4){
-			strtmp = '0' + strtmp;
+	var	result		= {};
+	result.hi_id	= hiUuid4;
+	result.low_id	= lowUuid4;
+	result.base		= base;
+
+	// raw not crypted token[256]
+	var	token = new Buffer(32);
+	for(var cnt = 0; cnt < 32; ++cnt){
+		if(cnt < 16){
+			token[cnt] = result.base[cnt] ^ hiUuid4[cnt];
+		}else{
+			token[cnt] = result.base[cnt] ^ lowUuid4[cnt - 16];
 		}
-		result += strtmp;
 	}
+
+	// sha256 token[256]
+	var cryptSha256		= crypto.createHash('sha256');
+	cryptSha256.update(token);
+	result.str_token	= cryptSha256.digest('hex');
+
+	// sha256 binary token[256]
+	result.token		= rawCvtNumberStringToBinBuffer(result.str_token, 16, 32);
+
 	return result;
 }
 
 //
-// Convert Hex string(64 or 128bit) to value array(4 or 8)
+// Return result
+// {
+//		str_hi_id:	hi uuid string
+//		hi_id:		Buffer[16] for hi uuid
+//		str_low_id:	low uuid string
+//		low_id:		Buffer[16] for low uuid
+//		str_base:	base string
+//		base:		Buffer[32] for base
+//		str_token:	hex[32] string for token
+//		token:		Buffer[32] for token
+// }
 //
-function rawConvertHexStringToBin(strval, is_128)
+function rawMakeStringToken256(strHiUuid4, strLowUuid4, strBase)
 {
-	if('boolean' !== typeof is_128){
-		is_128 = false;										// force 64
-	}
-	// normalization
-	strval = rawGetSafeString(strval);
+	var	hiUuid4		= rawCvtStrToBinUuid4(strHiUuid4);
+	var	lowUuid4	= rawCvtStrToBinUuid4(strLowUuid4);
 
-	// hex string length for 128bit(64bit) is 32(16) character.
-	// if strval length is shorter then 32(16), add '0' to head of strval.
-	var	char_count = (is_128 ? 32 : 16);
-	while(strval.length < char_count){
-		strval = '0' + strval;
-	}
-	// If strval length is over count, cut it.
-	if(char_count < strval.length){
-		strval = strval.substr((strval.length - char_count), char_count);
-	}
-
-	var	value = new Array(char_count / 4);					// value array length is 8 or 4
-	for(var pos = 0; pos < strval.length; pos += 4){		// strval.length is 32 or 16
-		var	tmpval = 0;
-		for(var subpos = 0; subpos < 4 && (subpos + pos) < strval.length; subpos += 2){
-			var	strbyte;
-			if((subpos + pos + 1) < strval.length){
-				strbyte = strval.substr(subpos + pos, 2);
-			}else{
-				strbyte = strval.substr(subpos + pos, 1);
-				strbyte += '0';
-			}
-			tmpval *= 16;
-			tmpval += parseInt(strbyte, 16);
-		}
-		value[(pos / 4)] = tmpval;
-	}
-	return value;
-}
-
-//
-// Convert Dec string to value array(4)
-//
-function rawConvertDocStringToBin64(strval)
-{
-	// normalization
-	strval		= rawGetSafeString(strval);
-	var	strhex	= parseInt(strval);
-	strhex		= strhex.toString(16);						// to Hex string
-
-	return rawConvertHexStringToBin(strhex, false);
-}
-
-//
-// Convert Dec or Hex string to value array(4)
-//
-function rawConvertStringToBin64(strval)
-{
-	// normalization
-	strval		= rawGetSafeString(strval);
-	if(null === strval.match(/[^0-9]/)){
-		// string has only 0-9 character => Dec string
-		strval	= parseInt(strval);
-		strval	= strval.toString(16);						// to Hex string
-	}
-	return rawConvertHexStringToBin(strval, false);
-}
-
-//
-// Convert Hex string(64bit) to binary value array(4)
-//
-function rawConvertHexStringToBin64(strval)
-{
-	return rawConvertHexStringToBin(strval, false);
-}
-
-//
-// Convert Hex string(128bit) to binary value array(8)
-//
-function rawConvertHexStringToBin128(strval)
-{
-	return rawConvertHexStringToBin(strval, true);
-}
-
-function rawConvertHexString128ToBin64(strval)
-{
-	var	binarr	= rawConvertHexStringToBin(strval, true);
-	var	result	= new Array(4);
-	result[0]	= binarr[4];
-	result[1]	= binarr[5];
-	result[2]	= binarr[6];
-	result[3]	= binarr[7];
-
-	return result;
-}
-
-//
-// Make XOR 64 bit value from two 64 bit value array
-//
-function rawMakeXorValue(value1, value2)
-{
-	var	result = new Array(4);
-	if(rawIsEmptyArray(value1) || value1.length < 4 || rawIsEmptyArray(value2) || value2.length < 4){
-		result[0] = 0;
-		result[1] = 0;
-		result[2] = 0;
-		result[3] = 0;
+	var	base;
+	if(rawIsSafeString(strBase)){
+		// string base is specified, then convert to buffer[32]
+		base = rawCvtNumberStringToBinBuffer(strBase, 16, 32);
 	}else{
-		result[0] = value1[0] ^ value2[0];
-		result[1] = value1[1] ^ value2[1];
-		result[2] = value1[2] ^ value2[2];
-		result[3] = value1[3] ^ value2[3];
+		// base is not specified, then it is made at here.
+		base = crypto.randomBytes(32);						// base data is random value in buffer[32]
 	}
+
+	var	result		= rawMakeToken256(hiUuid4, lowUuid4, base);
+	if(null == result){
+		return null;
+	}
+	result.str_hi_id	= strHiUuid4;
+	result.str_low_id	= strLowUuid4;
+	result.str_base		= base.toString('hex');
+
 	return result;
+}
+
+//
+// Converts a decimal or hexadecimal character string into a Buffer array(hexadecimal)
+// with a specified number of bytes.
+//
+//	strNumber:	string for decimal or hexadecimal number
+//	base:		radix(10 or 16)
+//	size:		output Buffer array size
+//
+//	result:		Buffer array
+//
+function rawCvtNumberStringToBinBuffer(strNumber, base, size)
+{
+	if(!rawIsSafeString(strNumber)){
+		return null;
+	}
+	if(16 != base && 10 != base){
+		return null;
+	}
+	if(10 == base){
+		// convert dec string to hex string
+		var	tmpNumber	= parseInt(strNumber, 10);
+		strNumber		= tmpNumber.toString(16);
+	}
+
+	var	uintarr	= new Uint8Array(strNumber.match(/.{1,2}/g).map(function(val){ return parseInt(val, 16); }));
+	var	binbuff	= new Buffer(size);
+	binbuff.fill(0);
+
+	var diff_length;
+	var	cnt;
+	if(size < uintarr.length){
+		// If input number array length is larger than required length, fill bottom.
+		diff_length	= uintarr.length - size;
+		for(cnt = uintarr.length; diff_length < cnt; --cnt){
+			binbuff[cnt - 1 - diff_length] = uintarr[cnt - 1];
+		}
+	}else{
+		// If required length is larger than input length, fill zero to top.
+		diff_length	= size - uintarr.length;
+		for(cnt = size; 0 < cnt; --cnt){
+			if((cnt -1) < diff_length){
+				break;
+			}
+			binbuff[cnt - 1] = uintarr[cnt - 1 - diff_length];
+		}
+	}
+	return binbuff;
+}
+
+function rawCvtNumberStringToUuid4(strNumber, base)
+{
+	var	bin_uuid4 = rawCvtNumberStringToBinBuffer(strNumber, base, 16);		// UUID4 is 16bytes
+	if(null == bin_uuid4){
+		return null;
+	}
+	return rawGetStrUuid4(bin_uuid4);
 }
 
 //---------------------------------------------------------
@@ -1156,6 +1270,11 @@ exports.checkSimpleJSON = function(str)
 	return rawCheckSimpleJSON(str);
 };
 
+exports.parseJSON = function(str)
+{
+	return rawParseJSON(str);
+};
+
 exports.isArray = function(arr)
 {
 	return rawIsArray(arr);
@@ -1235,6 +1354,21 @@ exports.isExpired = function(base)
 	return (convertUnixtime(base) < convertUnixtime());			// base(UTC ISO 8601) < now
 };
 
+exports.convertISOStringToUnixtime = function(iso)
+{
+	return rawConvertISOStringToUnixtime(iso);
+};
+
+exports.getExpireUnixtime = function(starttime, expiretime)
+{
+	return rawGetExpireUnixtime(starttime, expiretime);
+};
+
+exports.getExpireUnixtimeFromISOStrings = function(startiso, expireiso)
+{
+	return rawGetExpireUnixtimeFromISOStrings(startiso, expireiso);
+};
+
 exports.expandHierarchy = function(parent, children, separator)
 {
 	return rawExpandHierarchy(parent, children, separator);
@@ -1255,44 +1389,44 @@ exports.getNormalizeParameter = function(parameter, regex_ptn, pattern)
 	return rawGetNormalizeParameter(parameter, regex_ptn, pattern);
 };
 
-exports.getRandomBin64 = function()
+exports.getBinUuid4 = function()
 {
-	return rawGetRandomBin64();
+	return rawGetBinUuid4();
 };
 
-exports.convertBin64ToHexString = function(value)
+exports.getStrUuid4 = function(binUuid4)
 {
-	return rawConvertBin64ToHexString(value);
+	return rawGetStrUuid4(binUuid4);
 };
 
-exports.convertHexStringToBin64 = function(strval)
+exports.isSafeStrUuid4 = function(strUuid4)
 {
-	return rawConvertHexStringToBin64(strval);
+	return rawIsSafeStrUuid4(strUuid4);
 };
 
-exports.convertHexStringToBin128 = function(strval)
+exports.cvtStrToBinUuid4 = function(strUuid4)
 {
-	return rawConvertHexStringToBin128(strval);
+	return rawCvtStrToBinUuid4(strUuid4);
 };
 
-exports.convertDocStringToBin64 = function(strval)
+exports.makeToken256 = function(hiUuid4, lowUuid4, base)
 {
-	return rawConvertDocStringToBin64(strval);
+	return rawMakeToken256(hiUuid4, lowUuid4, base);
 };
 
-exports.convertStringToBin64 = function(strval)
+exports.makeStringToken256 = function(strHiUuid4, strLowUuid4, strBase)
 {
-	return rawConvertStringToBin64(strval);
+	return rawMakeStringToken256(strHiUuid4, strLowUuid4, strBase);
 };
 
-exports.convertHexString128ToBin64 = function(strval)
+exports.cvtNumberStringToBinBuffer = function(strNumber, base, size)
 {
-	return rawConvertHexString128ToBin64(strval);
+	return rawCvtNumberStringToBinBuffer(strNumber, base, size);
 };
 
-exports.makeXorValue = function(value1, value2)
+exports.cvtNumberStringToUuid4 = function(strNumber, base)
 {
-	return rawMakeXorValue(value1, value2);
+	return rawCvtNumberStringToUuid4(strNumber, base);
 };
 
 exports.getClientIpAddress = function(req)

--- a/lib/k2hr3config.js
+++ b/lib/k2hr3config.js
@@ -153,7 +153,12 @@ var	loadedConfig = (function()
 			timeoutparam:		'-W',									// Timeout parameter name for ping command
 			timeoutms:			5000									// Timeout millisecond for each checking            : 5000ms
 		},
-		allowcredauth:		true										// allow CORS access for authorization by credential
+		allowcredauth:		true,										// allow CORS access for authorization by credential
+
+		expiration:				{										// Expiration for Tokens
+			roletoken:			86400,									// Expire time(sec) for RoleToken                   : 24 * 60 * 60   = 1 day
+			regroletoken:		315360000								// Expire time(sec) for register host               : 10 * 356 * 24 * 60 * 60   = 10 years(no expire)
+		}
 	};
 
 	if(apiutil.isSafeEntity(config)){
@@ -364,6 +369,16 @@ var	loadedConfig = (function()
 		if(apiutil.isSafeEntity(config.allowcredauth) && 'boolean' == typeof config.allowcredauth && config.allowcredauth){
 			data.allowcredauth					= config.allowcredauth;
 		}
+
+		// Expiration for Tokens
+		if(apiutil.isSafeEntity(config.expiration)){
+			if(apiutil.isSafeEntity(config.expiration.roletoken) && !isNaN(config.expiration.roletoken)){
+				data.expiration.roletoken		= parseInt(config.expiration.roletoken);
+			}
+			if(apiutil.isSafeEntity(config.expiration.regroletoken) && !isNaN(config.expiration.regroletoken)){
+				data.expiration.regroletoken	= parseInt(config.expiration.regroletoken);
+			}
+		}
 	}
 	return data;
 }());
@@ -373,14 +388,14 @@ var	loadedConfig = (function()
 //
 function normalizePort(val)
 {
-	var	port = parseInt(val, 10);
-	if(isNaN(port)){
+	if(isNaN(val)){
 		// named pipe
 		if(!apiutil.isSafeString(val)){
 			return false;
 		}
 		return val;
 	}
+	var	port = parseInt(val, 10);
 	if(0 <= port){
 		// port number
 		return port;
@@ -654,6 +669,16 @@ var R3ApiConfig = (function()
 	proto.isAllowedCredentialAccess = function()
 	{
 		return this.loadedConfig.allowcredauth;
+	};
+
+	proto.getExpireTimeRoleToken = function()
+	{
+		return this.loadedConfig.expiration.roletoken;
+	};
+
+	proto.getExpireTimeRegRoleToken = function()
+	{
+		return this.loadedConfig.expiration.regroletoken;
 	};
 
 	return R3ApiConfig;

--- a/lib/k2hr3dkc.js
+++ b/lib/k2hr3dkc.js
@@ -178,7 +178,7 @@ function rawIncDecReferenceCount(dkcobj_permanent, fullyrn, increment)
 		r3logger.elog(resobj.message);
 		return resobj;
 	}
-	if(!apiutil.isSafeStrings(fullyrn)){
+	if(!apiutil.isSafeString(fullyrn)){
 		resobj.result	= false;
 		resobj.message	= 'some parameters aree wrong : fullyrn=' + JSON.stringify(fullyrn) + ', increment=' + JSON.stringify(increment);
 		r3logger.elog(resobj.message);
@@ -237,7 +237,7 @@ function rawCreateKeyTree(dkcobj_permanent, parent_key, keys, allow_empty_key)
 		r3logger.elog('parameter dkcobj_permanent is not object or not permanent');
 		return false;
 	}
-	if(!apiutil.isSafeStrings(parent_key)){
+	if(!apiutil.isSafeString(parent_key)){
 		r3logger.elog('parameters are wrong : parent_key=' + JSON.stringify(parent_key));
 		return false;
 	}
@@ -472,7 +472,7 @@ function rawInitKeyHierarchy(dkcobj_permanent)
 	// yrn:yahoo::::iaas
 	//
 	// [NOTE]
-	// We do not need value for iaas and iaas:openstack top key, but we need to make this key
+	// We do not need value for iaas and iaas:{openstack|k8s} top key, but we need to make this key
 	// for adding subkeys after processing. Thus we set value as dummy into it.
 	//
 	if(!dkcobj.setValue(keys.IAAS_TOP_KEY, keys.VALUE_ENABLE)){								// set value enable(dummy) -> yrn:yahoo::::iaas
@@ -482,10 +482,11 @@ function rawInitKeyHierarchy(dkcobj_permanent)
 		}
 		return false;
 	}
-	// create openstack key
-	subkeylist	= [keys.IAAS_OS_TOP_KEY];
-	if(!dkcobj.setSubkeys(keys.IAAS_TOP_KEY, subkeylist)){								// set subkey yrn:yahoo::::iaas:openstack -> yrn:yahoo::::iaas
-		r3logger.elog('could not set ' + keys.ANYTENANT_SERVICE_TOP_KEY + ' subkey under ' + keys.MASTER_SERVICE_TOP_KEY + ' key');
+
+	// create openstack and kubernetes key
+	subkeylist	= [keys.IAAS_OS_TOP_KEY, keys.IAAS_K8S_TOP_KEY];
+	if(!dkcobj.setSubkeys(keys.IAAS_TOP_KEY, subkeylist)){								// set subkey yrn:yahoo::::iaas:{openstack|k8s} -> yrn:yahoo::::iaas
+		r3logger.elog('could not set ' + keys.IAAS_OS_TOP_KEY + ' and ' + keys.IAAS_K8S_TOP_KEY + ' subkey under ' + keys.IAAS_TOP_KEY + ' key');
 		if(need_clean){
 			dkcobj.clean();
 		}
@@ -493,6 +494,13 @@ function rawInitKeyHierarchy(dkcobj_permanent)
 	}
 	if(!dkcobj.setValue(keys.IAAS_OS_TOP_KEY, keys.VALUE_ENABLE)){							// set value enable(dummy) -> yrn:yahoo::::iaas:openstack
 		r3logger.elog('could not set ' + keys.VALUE_ENABLE + ' value to ' + keys.IAAS_OS_TOP_KEY + ' key');
+		if(need_clean){
+			dkcobj.clean();
+		}
+		return false;
+	}
+	if(!dkcobj.setValue(keys.IAAS_K8S_TOP_KEY, keys.VALUE_ENABLE)){							// set value enable(dummy) -> yrn:yahoo::::iaas:k8s
+		r3logger.elog('could not set ' + keys.VALUE_ENABLE + ' value to ' + keys.IAAS_K8S_TOP_KEY + ' key');
 		if(need_clean){
 			dkcobj.clean();
 		}
@@ -2348,9 +2356,11 @@ function rawRemoveServiceTenant(user, tenant, service)
 //	service									: service name
 //	service_ip								: IP address string from service server
 //	service_port							: Port number from service server
+//	service_cuk								: cuk from service server
 //	service_roleyrn							: Role full yrn path for service server
 //	client_ip								: IP address string from client
 //	client_port								: Port number from client
+//	client_cuk								: cuk from client
 //	client_roleyrn							: Role full yrn path for client
 //
 //	return object
@@ -2439,9 +2449,9 @@ function rawGetServiceTenantResources(service, service_ip, service_port, service
 	}
 
 	//
-	// Check service ip+port is service's role member
+	// Check service ip+port+cuk is service's role member
 	//
-	if(!rawFindRoleHost(dkcobj, service_roleyrn, null, service_ip, service_port, service_cuk)){
+	if(!rawFindRoleHost(dkcobj, service_roleyrn, null, service_ip, service_port, service_cuk, false)){	// not strictly checking
 		resobj.result	= false;
 		resobj.message	= 'service ip(' + service_ip + ') and port(' + String(service_port) + ') and cuk(' + JSON.stringify(service_cuk) + ') is not service role(' + service_roleyrn + ') member.';
 		r3logger.elog(resobj.message);
@@ -2463,7 +2473,7 @@ function rawGetServiceTenantResources(service, service_ip, service_port, service
 	//
 	// Check client ip+port is service's role member
 	//
-	if(!rawFindRoleHost(dkcobj, client_roleyrn, null, client_ip, client_port, client_cuk)){
+	if(!rawFindRoleHost(dkcobj, client_roleyrn, null, client_ip, client_port, client_cuk, false)){		// not strictly checking
 		resobj.result	= false;
 		resobj.message	= 'client ip(' + client_ip + ') and port(' + String(client_port) + ') and cuk(' + JSON.stringify(client_cuk) + ') is not client role(' + client_roleyrn + ') member.';
 		r3logger.elog(resobj.message);
@@ -2747,7 +2757,7 @@ function rawGetUserId(username)
 //
 function rawRemoveComprehensionByNewTenants(user, tenant_list)
 {
-	if(!apiutil.isSafeStrings(user)){
+	if(!apiutil.isSafeString(user)){
 		r3logger.elog('user parameter is wrong');
 		return false;
 	}
@@ -2906,7 +2916,7 @@ function rawCreateRoleEx(dkcobj_permanent, user, tenant, service, role, policies
 	var	is_alias	= false;
 	var	fileter_cnt;
 
-	if(apiutil.isSafeStrings(service)){
+	if(apiutil.isSafeString(service)){
 		// service name is specified.
 		// the role is ACR(accessing crossed roles), then checking parameters for it.
 		// (policies, hosts, ips, aliases must be empty.)
@@ -3044,6 +3054,7 @@ function rawCreateRoleEx(dkcobj_permanent, user, tenant, service, role, policies
 	var	ip_key			= hosts_key	+ '/' + keys.HOSTS_IP_KW;								// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts/ip"
 	var	id_key			= role_key	+ '/' + keys.ID_KW;										// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/id"
 	var	alias_key		= role_key	+ '/' + keys.ALIAS_KW;									// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/@"
+	var	tokens_key		= role_key	+ '/' + keys.ROLE_TOKEN_KW;								// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/tokens"
 
 	var	value;
 	var	subkeylist;
@@ -3112,7 +3123,7 @@ function rawCreateRoleEx(dkcobj_permanent, user, tenant, service, role, policies
 
 	// policies key
 	value = dkcobj_permanent.getValue(policies_key, null, true, null);
-	value = JSON.parse(value);
+	value = apiutil.parseJSON(value);
 	if((is_policies && !apiutil.compareArray(value, policies)) || (!is_policies && (null === value || undefined === value))){
 		if(!dkcobj_permanent.setValue(policies_key, JSON.stringify(policies))){				// set value "policies" -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/policies
 			r3logger.elog('could not set ' + JSON.stringify(policies) + ' value to ' + policies_key + ' key');
@@ -3153,11 +3164,11 @@ function rawCreateRoleEx(dkcobj_permanent, user, tenant, service, role, policies
 
 	// id key
 	value = dkcobj_permanent.getValue(id_key, null, true, null);
-	value = JSON.parse(value);
-	if(apiutil.isEmptyArray(value) || value.length < 4){
-		// id value is made automatically by k2hr3
-		value = apiutil.getRandomBin64();
-		if(!dkcobj_permanent.setValue(id_key, JSON.stringify(value))){						// set value -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/id
+	if(!apiutil.isSafeStrUuid4(value)){
+		// If value is made by old version, it is JSON formated from 2byte binary array(4).
+		// In any case, reset it to the new value here.
+		value = apiutil.getStrUuid4();
+		if(!dkcobj_permanent.setValue(id_key, value)){										// set value -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/id
 			r3logger.elog('could not set ' + JSON.stringify(value) + ' value to ' + id_key + ' key');
 			return false;
 		}
@@ -3165,12 +3176,12 @@ function rawCreateRoleEx(dkcobj_permanent, user, tenant, service, role, policies
 
 	// aliases
 	value = dkcobj_permanent.getValue(alias_key, null, true, null);
-	value = JSON.parse(value);
+	value = apiutil.parseJSON(value);
 	if(is_alias){
 		var	cnt;
 		var	tmpres;
 		if(0 === alias_roles.length){
-			if(null !== value && undefined !== value){
+			if(null !== value){
 				// if there is alias array, alias role reference is needed to decrement
 				if(!apiutil.isEmptyArray(value)){
 					for(cnt = 0; cnt < value.length; ++cnt){
@@ -3226,6 +3237,16 @@ function rawCreateRoleEx(dkcobj_permanent, user, tenant, service, role, policies
 			}
 		}
 	}
+
+	// check tokens key
+	value = dkcobj_permanent.getValue(tokens_key, null, true, null);
+	if(!apiutil.isSafeString(value)){
+		if(!dkcobj_permanent.setValue(tokens_key, keys.VALUE_ENABLE)){						// set value enable(dummy) -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/tokens
+			r3logger.elog('could not set ' + keys.VALUE_ENABLE + ' value to ' + tokens_key + ' key');
+			return false;
+		}
+	}
+
 	return true;
 }
 
@@ -3320,7 +3341,7 @@ function rawRemoveRoleEx(dkcobj_permanent, tenant, service, role)
 	//
 	var	keys;
 	var	is_service	= false;
-	if(apiutil.isSafeStrings(service)){
+	if(apiutil.isSafeString(service)){
 		// service name is specified.
 		//
 		is_service	= true;
@@ -3376,6 +3397,7 @@ function rawRemoveRoleEx(dkcobj_permanent, tenant, service, role)
 	var	ip_key			= hosts_key	+ '/' + keys.HOSTS_IP_KW;								// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts/ip"
 	var	id_key			= role_key	+ '/' + keys.ID_KW;										// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/id"
 	var	alias_key		= role_key	+ '/' + keys.ALIAS_KW;									// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/@"
+	var	tokens_key		= role_key	+ '/' + keys.ROLE_TOKEN_KW;								// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/tokens"
 	var	subkeylist;
 
 	// remove all both hosts/{name, ip}/... keys under hosts key
@@ -3390,6 +3412,12 @@ function rawRemoveRoleEx(dkcobj_permanent, tenant, service, role)
 		r3logger.dlog('could not remove ' + ip_key + 'key, probably it is not existed');
 	}
 
+	// remove role tokens subkeys
+	subkeylist = apiutil.getSafeArray(dkcobj_permanent.getSubkeys(tokens_key, false));		// not check attributes
+	if(apiutil.isEmptyArray(subkeylist) && !r3token.directRemoveRoleTokens(dkcobj_permanent, subkeylist)){	// remove all role token from yrn:yahoo::::token:role
+		r3logger.dlog('failed to remove ' + JSON.stringify(subkeylist) + ' role tokens under role token key, but continue...');
+	}
+
 	// remove subkeys under role key
 	if(!dkcobj_permanent.remove(policies_key, true)){										// remove yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/policies
 		r3logger.dlog('could not remove ' + policies_key + 'key, probably it is not existed');
@@ -3402,6 +3430,9 @@ function rawRemoveRoleEx(dkcobj_permanent, tenant, service, role)
 	}
 	if(!dkcobj_permanent.remove(id_key, true)){												// remove yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/id
 		r3logger.dlog('could not remove ' + id_key + 'key, probably it is not existed');
+	}
+	if(!dkcobj_permanent.remove(tokens_key, true)){											// remove yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/tokens
+		r3logger.dlog('could not remove ' + tokens_key + 'key, probably it is not existed');
 	}
 	if(!dkcobj_permanent.remove(alias_key, true)){											// remove yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/@
 		r3logger.dlog('could not remove ' + alias_key + 'key, probably it is not existed');
@@ -3421,6 +3452,9 @@ function rawRemoveRoleEx(dkcobj_permanent, tenant, service, role)
 			update	= true;
 		}
 		if(apiutil.removeStringFromArray(subkeylist, id_key)){
+			update	= true;
+		}
+		if(apiutil.removeStringFromArray(subkeylist, tokens_key)){
 			update	= true;
 		}
 		if(apiutil.removeStringFromArray(subkeylist, alias_key)){
@@ -3627,7 +3661,7 @@ function rawGetRole(role, is_expand)
 {
 	var	resobj = {result: true, message: null};
 
-	if(!apiutil.isSafeStrings(role)){
+	if(!apiutil.isSafeString(role)){
 		resobj.result	= false;
 		resobj.message	= 'some parameters are wrong : role=' + JSON.stringify(role);
 		r3logger.elog(resobj.message);
@@ -3696,7 +3730,7 @@ function rawGetRoles(dkcobj_permanent, role, roledata, is_expand, checked_roles,
 		r3logger.elog('parameter dkcobj_permanent is not object or not permanent');
 		return false;
 	}
-	if(!apiutil.isSafeStrings(role)){
+	if(!apiutil.isSafeString(role)){
 		r3logger.elog('some parameters are wrong : role=' + JSON.stringify(role));
 		return false;
 	}
@@ -3757,7 +3791,7 @@ function rawGetRoles(dkcobj_permanent, role, roledata, is_expand, checked_roles,
 	value = dkcobj_permanent.getValue(alias_key, null, true, null);
 	if(is_expand){
 		if(apiutil.isSafeEntity(value)){
-			value = JSON.parse(value);
+			value = apiutil.parseJSON(value);
 			if(!apiutil.isEmptyArray(value)){
 				for(cnt = 0; cnt < value.length; ++cnt){
 					// get alias roles
@@ -3768,7 +3802,7 @@ function rawGetRoles(dkcobj_permanent, role, roledata, is_expand, checked_roles,
 			}
 		}
 	}else{
-		if(apiutil.isSafeEntity(value)){
+		if(apiutil.checkSimpleJSON(value)){
 			value = JSON.parse(value);
 		}else{
 			value = [];
@@ -3778,7 +3812,7 @@ function rawGetRoles(dkcobj_permanent, role, roledata, is_expand, checked_roles,
 
 	// get role policies
 	value = dkcobj_permanent.getValue(policies_key, null, true, null);
-	value = JSON.parse(value);
+	value = apiutil.parseJSON(value);
 	if(!apiutil.isEmptyArray(value)){
 		if(apiutil.isEmptyArray(roledata[keys.VALUE_POLICIES_TYPE])){
 			roledata[keys.VALUE_POLICIES_TYPE]	= new Array(0);
@@ -3950,7 +3984,7 @@ function rawAddHost(tenant, role, service, hostname, ip, port, cuk, extra)
 						ip:			null,
 						port:		port,
 						cuk:		cuk,
-						id:			apiutil.getRandomBin64(),								// id is random value array
+						id:			apiutil.getStrUuid4(),
 						extra:		apiutil.getSafeString(extra)
 					  };
 			/* eslint-enable indent, no-mixed-spaces-and-tabs */
@@ -3964,7 +3998,7 @@ function rawAddHost(tenant, role, service, hostname, ip, port, cuk, extra)
 						ip:			ip[cnt],												// ip address
 						port:		port,
 						cuk:		cuk,
-						id:			apiutil.getRandomBin64(),								// id is random value array
+						id:			apiutil.getStrUuid4(),
 						extra:		apiutil.getSafeString(extra)
 					  };
 			/* eslint-enable indent, no-mixed-spaces-and-tabs */
@@ -4017,7 +4051,7 @@ function rawCreateRoleHosts(dkcobj_permanent, role_key, hosts, is_clear_old_host
 		r3logger.elog('parameter dkcobj_permanent is not object or not permanent');
 		return false;
 	}
-	if(!apiutil.isSafeStrings(role_key)){
+	if(!apiutil.isSafeString(role_key)){
 		r3logger.elog('some parameters are wrong : role_key=' + JSON.stringify(role_key));
 		return false;
 	}
@@ -4088,7 +4122,10 @@ function rawCreateRoleHosts(dkcobj_permanent, role_key, hosts, is_clear_old_host
 		// because if port is any(0), we need to check all existed host(ip) list.
 		//
 		for(cnt = 0; cnt < hosts.length; ++cnt){
-			if(!rawRemoveRoleHost(dkcobj_permanent, role_key, hosts[cnt].hostname, hosts[cnt].ip, hosts[cnt].port, hosts[cnt].cuk)){
+			// [NOTE]
+			// Delete as many target HOSTs as possible(does not match exactly).
+			//
+			if(!rawRemoveRoleHost(dkcobj_permanent, role_key, hosts[cnt].hostname, hosts[cnt].ip, hosts[cnt].port, hosts[cnt].cuk, false)){
 				r3logger.elog('could not remove (' + JSON.stringify(hosts[cnt]) + ') hosts key and subkeys under ' + hosts_key + '/{name or ip} key.');
 				return false;
 			}
@@ -4105,14 +4142,34 @@ function rawCreateRoleHosts(dkcobj_permanent, role_key, hosts, is_clear_old_host
 	// loop for add host(ip) to under hosts/{name or ip} key
 	for(var cnt = 0; cnt < hosts.length; ++cnt){
 		// make one host information
+		var	tg_host_info		= hosts[cnt];
 		var	tg_port				= (0 === hosts[cnt].port ? keys.VALUE_ANY_PORT : String(hosts[cnt].port));
 		var	tg_cuk				= (null === hosts[cnt].cuk ? '' : apiutil.getSafeString(hosts[cnt].cuk).trim());
-		var	tg_extra			= (null === hosts[cnt].extra ? '' : apiutil.getSafeString(hosts[cnt].extra).trim());
 		var	is_ip				= apiutil.isSafeString(hosts[cnt].ip);
 		var	tg_parent_key		= (is_ip ? ip_key : name_key);								// yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts/{name or ip}
 		var	tg_key				= tg_parent_key + '/' + (is_ip ? hosts[cnt].ip : hosts[cnt].hostname) + keys.VALUE_HOST_SEP + tg_port + keys.VALUE_HOST_SEP + tg_cuk;	// yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts/{name or ip}/"{ip or hostname} port cuk"
-		var	tg_host_info		= hosts[cnt];
-		tg_host_info[keys.ID_KW]= apiutil.getRandomBin64();									// host id = random value
+
+		var	tg_extra;
+		if(!apiutil.isSafeEntity(hosts[cnt].extra)){
+			tg_extra			= '';
+		}else if(apiutil.isSafeString(hosts[cnt].extra)){
+			// Currently, extra supports only openstack and kubernets.
+			tg_extra			= apiutil.getSafeString(hosts[cnt].extra).trim();
+
+			// a case of kubernetes type
+			if(tg_extra == keys.VALUE_K8S_V1){
+				// check cuk and set host information
+				if(!rawSetHostInfoValueFromKubernetesCuk(tg_host_info, tg_cuk, (is_ip ? hosts[cnt].ip : null))){
+					r3logger.elog('could not set host(' + hosts[cnt] + '), because kubernetes cuk is something wrong.');
+					return false;
+				}
+			}
+		}else{
+			// Currently we do not support this type, but set this.
+			tg_extra			= hosts[cnt].extra;
+		}
+
+		tg_host_info[keys.ID_KW]= apiutil.getStrUuid4();									// host id = UUID4
 		var	tg_value			= JSON.stringify(tg_host_info);
 
 		if(!dkcobj_permanent.setValue(tg_key, tg_value)){									// set value to key -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts/{name or ip}/"{ip or hostname} port cuk"
@@ -4161,28 +4218,251 @@ function rawCreateRoleHosts(dkcobj_permanent, role_key, hosts, is_clear_old_host
 	return result;
 }
 
+//
+// Utilities function for kubernetes cuk
+//
+// [NOTE]
+// kubernetes CUK is processed in the following format and passed to K2HR3 API.
+// This function converts a CUK string to the original object.
+//
+//	CUK string = url encode	( base64 encoding ( JSON string( cuk object ) ) ) )
+//
+function rawParseKubernetesCuk(cuk)
+{
+	if(!apiutil.isSafeString(cuk)){
+		return null;
+	}
+	// decode url encode
+	var	cuk_base64	= cuk.replace(/%3d/g, '=').replace(/_/g, '/').replace(/-/g, '+');	// '%3d' is not necessary but it is executed just in case
+	if(!apiutil.isSafeString(cuk_base64)){
+		return null;
+	}
+	try{
+		// decode base64
+		var	buff64		= new Buffer(cuk_base64, 'base64');
+		if(!apiutil.isSafeEntity(buff64)){
+			return null;
+		}
+		var cuk_json	= buff64.toString('ascii');
+		if(!apiutil.isSafeString(cuk_json)){
+			return null;
+		}
+		// parse json
+		var cuk_obj		= apiutil.parseJSON(cuk_json);
+		if(!apiutil.isSafeEntity(cuk_obj)){
+			return null;
+		}
+	}catch(exception){
+		return null;
+	}
+
+	// [NOTE]
+	// the cuk object must have some keys, you can see in k2hr3-kube-init.sh
+	//
+	var	keys = r3keys();
+	if(	!apiutil.isSafeString(cuk_obj[keys.K8S_NAMESPACE_INCUK_KEY])	||
+		!apiutil.isSafeString(cuk_obj[keys.K8S_SA_INCUK_KEY])			||
+		!apiutil.isSafeString(cuk_obj[keys.K8S_NODENAME_INCUK_KEY])		||
+		!apiutil.isSafeString(cuk_obj[keys.K8S_NODEIP_INCUK_KEY])		||
+		!apiutil.isSafeString(cuk_obj[keys.K8S_PODNAME_INCUK_KEY])		||
+		!apiutil.isSafeString(cuk_obj[keys.K8S_PODID_INCUK_KEY])		||
+		!apiutil.isSafeString(cuk_obj[keys.K8S_PODIP_INCUK_KEY])		||
+		!apiutil.isSafeString(cuk_obj[keys.K8S_CONTAINERID_INCUK_KEY])	||
+		!apiutil.isSafeString(cuk_obj[keys.K8S_RAND_INCUK_KEY])			)
+	{
+		r3logger.dlog('kubernetes cuk(' + JSON.stringify(cuk) + ') does not have some keys.');
+		return null;
+	}
+	return cuk_obj;
+}
+
+//
+// Utilities function for kubernetes cuk
+//
+// [NOTE]
+// The kubernetes CUK is created from following object.
+//	cuk object = {
+//		k8s_namespace:			<namespace of kubernets to which the container belongs>
+//		k8s_service_account:	<service account of kubernets to which the container belongs>
+//		k8s_node_name:			<node name on which the container is running>
+//		k8s_node_ip:			<node ip address on which the container is running>
+//		k8s_pod_name:			<pod name on which the container is running>
+//		k8s_pod_id:				<pod id on which the container is running>
+//		k8s_pod_ip:				<pod ip address on which the container is running>
+//		k8s_container_id:		<container id issued by docker>
+//		k8s_k2hr3_rand:			<random 32 byte value formatted hex string created by k2hr3-kube-init.sh>
+//	}
+//
+// This function compares CUK's node ip address with the passed host_ip and raises an error
+// if it does not match.
+// By doing this, when registering the role member host, it is checked whether CUK is correctly
+// generated when host registers from K2HR3 API.
+//
+function rawSetHostInfoValueFromKubernetesCuk(host_info, cuk, host_ip)
+{
+	if(!apiutil.isSafeEntity(host_info)){
+		return false;
+	}
+	if(!apiutil.isSafeString(host_ip)){
+		r3logger.elog('ip address(' + JSON.stringify(host_ip) + ') for checking kubernetes cuk is not string value.');
+		return false;
+	}
+
+	// parse cuk
+	var	cuk_obj = rawParseKubernetesCuk(cuk);
+	if(!apiutil.isSafeEntity(cuk_obj)){
+		r3logger.elog('cuk(' + JSON.stringify(cuk) + ') is not base64 url encode value.');
+		return false;
+	}
+
+	// check host ip address
+	var	keys = r3keys();
+	if(cuk_obj[keys.K8S_NODEIP_INCUK_KEY] != host_ip){
+		r3logger.elog('ip address(' + JSON.stringify(cuk_obj[keys.K8S_NODEIP_INCUK_KEY]) + ') in kubernetes cuk(' + JSON.stringify(cuk) + ') is not as same as requesting host ip(' + JSON.stringify(host_ip) + ').');
+		return false;
+	}
+
+	// set to host information with checking
+	Object.keys(cuk_obj).forEach(function(key){
+		if(apiutil.isSafeString(cuk_obj[key])){
+			host_info[key] = cuk_obj[key];
+		}else{
+			r3logger.wlog('key(' + JSON.stringify(key) + ') in kubernetes cuk(' + JSON.stringify(cuk) + ') is not safe string, then skip this.');
+		}
+	});
+
+	return true;
+}
+
+//
+// Utilities function for kubernetes cuk
+//
+// Compare host information(which is set in role ip address member) and cuk object.
+//
+function rawCompareHostInfoValueAndKubernetesCuk(host_info, cuk)
+{
+	if(!apiutil.isSafeEntity(host_info)){
+		return false;
+	}
+
+	// parse cuk
+	var	cuk_obj = rawParseKubernetesCuk(cuk);
+	if(!apiutil.isSafeEntity(cuk_obj)){
+		r3logger.elog('cuk(' + JSON.stringify(cuk) + ') is not base64 url encode value.');
+		return false;
+	}
+
+	// host_info object must have some keys.
+	var	keys = r3keys();
+	if(	!apiutil.isSafeString(host_info[keys.K8S_NAMESPACE_INCUK_KEY])	||
+		!apiutil.isSafeString(host_info[keys.K8S_SA_INCUK_KEY])			||
+		!apiutil.isSafeString(host_info[keys.K8S_NODENAME_INCUK_KEY])	||
+		!apiutil.isSafeString(host_info[keys.K8S_NODEIP_INCUK_KEY])		||
+		!apiutil.isSafeString(host_info[keys.K8S_PODNAME_INCUK_KEY])	||
+		!apiutil.isSafeString(host_info[keys.K8S_PODID_INCUK_KEY])		||
+		!apiutil.isSafeString(host_info[keys.K8S_PODIP_INCUK_KEY])		||
+		!apiutil.isSafeString(host_info[keys.K8S_CONTAINERID_INCUK_KEY])||
+		!apiutil.isSafeString(host_info[keys.K8S_RAND_INCUK_KEY])		)
+	{
+		r3logger.elog('host information value(' + JSON.stringify(host_info) + ') does not have some keys.');
+		return false;
+	}
+
+	// compare
+	if(	host_info[keys.K8S_NAMESPACE_INCUK_KEY]		!= cuk_obj[keys.K8S_NAMESPACE_INCUK_KEY]	||
+		host_info[keys.K8S_SA_INCUK_KEY]			!= cuk_obj[keys.K8S_SA_INCUK_KEY]			||
+		host_info[keys.K8S_NODENAME_INCUK_KEY]		!= cuk_obj[keys.K8S_NODENAME_INCUK_KEY]		||
+		host_info[keys.K8S_NODEIP_INCUK_KEY]		!= cuk_obj[keys.K8S_NODEIP_INCUK_KEY]		||
+		host_info[keys.K8S_PODNAME_INCUK_KEY]		!= cuk_obj[keys.K8S_PODNAME_INCUK_KEY]		||
+		host_info[keys.K8S_PODID_INCUK_KEY]			!= cuk_obj[keys.K8S_PODID_INCUK_KEY]		||
+		host_info[keys.K8S_PODIP_INCUK_KEY]			!= cuk_obj[keys.K8S_PODIP_INCUK_KEY]		||
+		host_info[keys.K8S_CONTAINERID_INCUK_KEY]	!= cuk_obj[keys.K8S_CONTAINERID_INCUK_KEY]	||
+		host_info[keys.K8S_RAND_INCUK_KEY]			!= cuk_obj[keys.K8S_RAND_INCUK_KEY]			)
+	{
+		r3logger.dlog('host information value(' + JSON.stringify(host_info) + ') is not as same as cuk( + JSON.stringify(cuk_obj) + ).');
+		return false;
+	}
+	return true;
+}
+
+//
+// Utilities function for kubernetes cuk
+//
+// Check cuk for kubernetes
+//
+function rawIsKubernetesCuk(cuk)
+{
+	// parse cuk
+	var	cuk_obj = rawParseKubernetesCuk(cuk);
+	if(!apiutil.isSafeEntity(cuk_obj)){
+		return false;
+	}
+	return true;
+}
+
+//
+// Utilities function for kubernetes cuk
+//
+// Compare ip address and cuk object's node ip address.
+//
+function rawCompareIpAndKubernetesCuk(ip, cuk)
+{
+	if(!apiutil.isSafeString(ip)){
+		return false;
+	}
+
+	// parse cuk
+	var	cuk_obj = rawParseKubernetesCuk(cuk);
+	if(!apiutil.isSafeEntity(cuk_obj)){
+		r3logger.elog('cuk(' + JSON.stringify(cuk) + ') is not base64 url encode value.');
+		return false;
+	}
+
+	// compare
+	var	keys = r3keys();
+	if(ip != cuk_obj[keys.K8S_NODEIP_INCUK_KEY]){
+		return false;
+	}
+	return true;
+}
+
+// Utility for cuk(custom unique key)
+//
+// return	:	extra string made from cuk
+//
+function rawGetExtraFromCuk(cuk)
+{
+	if(apiutil.isSafeString(cuk)){
+		var	keys	= r3keys();
+		var	cuk_obj	= rawParseKubernetesCuk(cuk);
+		if(null == cuk_obj){
+			return keys.VALUE_OPENSTACK_V1;
+		}else{
+			return keys.VALUE_K8S_V1;
+		}
+	}else{
+		// unknown
+		return null;
+	}
+}
+
 //---------------------------------------------------------
 // remove host raw function
 //---------------------------------------------------------
 // tenant			:	tenant name
 // service			:	service name if role is not full yrn
 // role				:	role name or full yrn role
-// hostname			:	hostname string or array
-// ip				:	ip address or array
-// port				:	port number(0, undefined, null means any)
-// cuk				:	container unique key(undefined, null means any)
-//
-// [NOTE]
-// Please specify either hostname or ip.
-// If port is any(0), this function check all port data in hostname/ip.
-// If the service name is specified when role is not full yrn path,
-// the host is found in tenant role under service.
-// The service name can be allowed undefined and null.
+// target			:	target hostname or ip address string or array
+// tg_port			:	target port number(0, undefined, null means any)
+// tg_cuk			:	target container unique key(undefined, null means any)
+// req_ip			:	requester ip address(when need to check)
+// req_port			:	requester port number(when req_ip is specified)
+// req_cuk			:	requester container unique key(when req_ip is specified)
 //
 // The hosts key under role key(yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}})
 // must exist.
 //
-function rawRemoveHost(tenant, service, role, hostname, ip, port, cuk)
+function rawRemoveHost(tenant, service, role, target, tg_port, tg_cuk, req_ip, req_port, req_cuk)
 {
 	var	resobj = {result: true, message: null};
 
@@ -4192,27 +4472,70 @@ function rawRemoveHost(tenant, service, role, hostname, ip, port, cuk)
 		r3logger.elog(resobj.message);
 		return resobj;
 	}
-	if(!apiutil.isSafeString(hostname) && apiutil.isEmptyArray(hostname) && !apiutil.isSafeString(ip) && apiutil.isEmptyArray(ip)){
+	// target hostname/ip/port/cuk
+	if(!apiutil.isSafeString(target) && apiutil.isEmptyArray(target)){
 		resobj.result	= false;
-		resobj.message	= 'both hostname and ip parameters are empty.';
+		resobj.message	= 'target(hostname or ip address) is empty.';
 		r3logger.elog(resobj.message);
 		return resobj;
 	}
-	if(!apiutil.isSafeEntity(port)){
-		port = 0;
-	}else if(isNaN(port)){
+	var	tg_host	= null;
+	var	tg_ip	= null;
+	if(apiutil.isSafeString(target)){
+		target = [target];
+	}
+	for(var cnt = 0; cnt < target.length; ++cnt){
+		if(apiutil.isIpAddressString(target[cnt])){
+			if(null == tg_ip){
+				tg_ip = [];
+			}
+			tg_ip.push(target[cnt]);
+		}else{
+			if(null == tg_host){
+				tg_host = [];
+			}
+			tg_host.push(target[cnt]);
+		}
+	}
+	if(!apiutil.isSafeEntity(tg_port)){
+		tg_port = 0;
+	}else if(isNaN(tg_port)){
 		resobj.result	= false;
-		resobj.message	= 'port(' + JSON.stringify(port) + ') parameter is wrong.';
+		resobj.message	= 'target port(' + JSON.stringify(tg_port) + ') parameter is wrong.';
 		r3logger.elog(resobj.message);
 		return resobj;
 	}
-	if(!apiutil.isSafeString(cuk)){
-		cuk = null;
+	if(!apiutil.isSafeString(tg_cuk)){
+		tg_cuk = null;
+	}
+
+	// requester ip/port/cuk is optional
+	if(!apiutil.isSafeString(req_ip)){
+		// not need to check requester ip+port+cuk
+		if(apiutil.isSafeEntity(req_port) || apiutil.isSafeString(req_cuk)){
+			resobj.result	= false;
+			resobj.message	= 'requester port(' + JSON.stringify(req_port) + ') and cuk(' + JSON.stringify(req_cuk) + ') parameters must be empty.';
+			r3logger.elog(resobj.message);
+			return resobj;
+		}
+	}else{
+		// need to check requester ip+port+cuk
+		if(!apiutil.isSafeEntity(req_port)){
+			req_port = 0;
+		}else if(isNaN(req_port)){
+			resobj.result	= false;
+			resobj.message	= 'requester port(' + JSON.stringify(req_port) + ') parameter is wrong.';
+			r3logger.elog(resobj.message);
+			return resobj;
+		}
+		if(!apiutil.isSafeString(req_cuk)){
+			req_cuk = null;
+		}
 	}
 	if(apiutil.isSafeString(service)){
-		service			= service.toLowerCase();
+		service	= service.toLowerCase();
 	}else{
-		service			= null;
+		service	= null;
 	}
 
 	// check role name is only name or full yrn path
@@ -4242,6 +4565,7 @@ function rawRemoveHost(tenant, service, role, hostname, ip, port, cuk)
 		role = rolematches[3];
 	}
 
+	// dkc
 	var	dkcobj			= k2hdkc(dkcconf, dkcport, true, false);							// use permanent object(need to clean)
 	if(!rawInitKeyHierarchy(dkcobj)){
 		resobj.result	= false;
@@ -4256,10 +4580,23 @@ function rawRemoveHost(tenant, service, role, hostname, ip, port, cuk)
 	//
 	var	role_key		= keys.ROLE_TOP_KEY + ':' + role;									// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}"
 
+	// check requester
+	if(apiutil.isSafeString(req_ip)){
+		var	found_host = rawFindRoleHost(dkcobj, role_key, null, req_ip, req_port, req_cuk, false);		// not strictly checking
+		if(apiutil.isEmptyArray(found_host)){
+			// requester ip+port+cuk is not role member.
+			resobj.result	= false;
+			resobj.message	= 'requester ip(' + JSON.stringify(req_ip) + '), port(' + JSON.stringify(req_port) + '), cuk(' + JSON.stringify(req_cuk) + ') is not role(' + JSON.stringify(role) + ') member.';
+			r3logger.elog(resobj.message);
+			dkcobj.clean();
+			return resobj;
+		}
+	}
+
 	// remove host
-	if(!rawRemoveRoleHost(dkcobj, role_key, hostname, ip, port, cuk)){						// remove host from -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts
+	if(!rawRemoveRoleHost(dkcobj, role_key, tg_host, tg_ip, tg_port, tg_cuk, false)){		// remove host from -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts
 		resobj.result	= false;
-		resobj.message	= 'could not remove host(hostname=' + JSON.stringify(hostname) + ', ip=' + JSON.stringify(ip) + ', port=' + String(port) + ', cuk=' + JSON.stringify(cuk) + ') from hosts under role(' + role + ').';
+		resobj.message	= 'could not remove host(hostname=' + JSON.stringify(tg_host) + ', ip=' + JSON.stringify(tg_ip) + ', port=' + String(tg_port) + ', cuk=' + JSON.stringify(tg_cuk) + ') from hosts under role(' + role + ').';
 		r3logger.elog(resobj.message);
 		dkcobj.clean();
 		return resobj;
@@ -4277,17 +4614,12 @@ function rawRemoveHost(tenant, service, role, hostname, ip, port, cuk)
 // ip				:	ip address or array
 // port				:	port number(0, undefined, null means any)
 // cuk				:	container unique key(undefined, null means any)
-//
-// [NOTE]
-// If port is any(0), this function check all port data in hostname/ip.
-// Current, this function does not have comparison of extra data.
-// It is that extra data is only explain of host information, then this
-// function does not use it for removing host.
+// is_strict		:	check for exact mate of parameters such as port/cuk
 //
 // The hosts/name or hosts/ip key under role key(yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}})
 // must exist.
 //
-function rawRemoveRoleHost(dkcobj_permanent, role_key, hostname, ip, port, cuk)
+function rawRemoveRoleHost(dkcobj_permanent, role_key, hostname, ip, port, cuk, is_strict)
 {
 	if(!(dkcobj_permanent instanceof Object) || !dkcobj_permanent.isPermanent()){
 		r3logger.elog('parameter dkcobj_permanent is not object or not permanent');
@@ -4310,9 +4642,12 @@ function rawRemoveRoleHost(dkcobj_permanent, role_key, hostname, ip, port, cuk)
 	if(!apiutil.isSafeString(cuk)){
 		cuk = null;
 	}
+	if('boolean' != typeof is_strict){
+		is_strict = true;
+	}
 
 	// find target hosts
-	var	found_host = rawFindRoleHost(dkcobj_permanent, role_key, hostname, ip, port, cuk);
+	var	found_host = rawFindRoleHost(dkcobj_permanent, role_key, hostname, ip, port, cuk, is_strict);
 	if(apiutil.isEmptyArray(found_host)){
 		// target host is not found, so nothing to do.
 		return true;
@@ -4368,10 +4703,10 @@ function rawRemoveRoleHost(dkcobj_permanent, role_key, hostname, ip, port, cuk)
 		//
 		for(cnt = 0; cnt < tg_ip_subkeylist.length; ++cnt){
 			// get extra data
-			var	value = dkcobj_permanent.getValue(tg_ip_subkeylist[cnt], null, true, null);	// get value -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts/{name or ip}/"{ip or hostname} port cuk"
-			if(apiutil.checkSimpleJSON(value)){
+			var	value	= dkcobj_permanent.getValue(tg_ip_subkeylist[cnt], null, true, null);	// get value -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts/{name or ip}/"{ip or hostname} port cuk"
+			value		= apiutil.parseJSON(value);
+			if(apiutil.isSafeEntity(value)){
 				// remove key under iaas key
-				value = JSON.parse(value);
 				if(!rawRemoveIpsByCukEx(dkcobj_permanent, cuk, value.extra, null, false)){		// do not remove under yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts/{name or ip} key
 					// If there is some ip address to one cuk, probably this
 					// function return error after first time, thus we continue...
@@ -4415,7 +4750,7 @@ function rawRemoveRoleHostAll(dkcobj_permanent, role_key, is_hostnames)
 		r3logger.elog('parameter dkcobj_permanent is not object or not permanent');
 		return false;
 	}
-	if(!apiutil.isSafeStrings(role_key)){
+	if(!apiutil.isSafeString(role_key)){
 		r3logger.elog('some parameters are wrong : role_key=' + JSON.stringify(role_key));
 		return false;
 	}
@@ -4509,13 +4844,13 @@ function rawRemoveRoleHostAll(dkcobj_permanent, role_key, is_hostnames)
 //
 // [Array element object]
 // {
-//		cuk:	"******"	(Openstack instance id, etc)
+//		cuk:	"******"	(Openstack instance id or custom value from kubernetes, etc)
 //		subkey:	"******"	(IP address's full key path: "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts/ip/<ip> <port> <cuk>")
-//		extra:	"******"	(extra string: "openstack-auto-v1" etc)
+//		extra:	"******"	(extra string: 'openstack-auto-v1', 'k8s-auto-v1' etc)
 // }
 //
 // [NOTE]
-// Current supports only OpenStack CUK, then extra is allowed only "openstack-auto-v1" now.
+// Current supports openStack and kubernetes CUK, then extra is allowed only 'openstack-auto-v1, 'k8s-auto-v1' now.
 //
 function rawAddIpsByCuk(dkcobj_permanent, cuk_list)
 {
@@ -4531,11 +4866,8 @@ function rawAddIpsByCuk(dkcobj_permanent, cuk_list)
 	//
 	// keys
 	//
-	var	keys		= r3keys();
-	//var iaas_key	= keys.IAAS_TOP_KEY;														// "yrn:yahoo::::iaas"
-	var	top_key		= keys.IAAS_OS_TOP_KEY;														// "yrn:yahoo::::iaas:openstack"
-	var	top_subkeys	= apiutil.getSafeArray(dkcobj_permanent.getSubkeys(top_key, true));			// get subkey list from yrn:yahoo::::iaas:openstack
-	var	result		= true;
+	var	keys	= r3keys();
+	var	result	= true;
 
 	// loop
 	for(var cnt = 0; cnt < cuk_list.length; ++cnt){
@@ -4545,41 +4877,42 @@ function rawAddIpsByCuk(dkcobj_permanent, cuk_list)
 			continue;
 		}
 
-		// [TODO]
-		// Current checks extra only Openstack
-		//
-		if(cuk_list[cnt].extra != keys.VALUE_OPENSTACK_V1){
-			r3logger.dlog('extra in list[' + cnt.toString() + '] is not ' + keys.VALUE_OPENSTACK_V1 + ', current is only support ' + keys.VALUE_OPENSTACK_V1);
+		// Current checks extra only openstack and kubernetes
+		if(cuk_list[cnt].extra != keys.VALUE_OPENSTACK_V1 && cuk_list[cnt].extra != keys.VALUE_K8S_V1){
+			r3logger.dlog('extra in list[' + cnt.toString() + '] is not ' + keys.VALUE_OPENSTACK_V1 + ' nor ' + keys.VALUE_K8S_V1);
 			continue;
 		}
 
-		var	cuk_key		= keys.IAAS_OS_TOP_KEY + ':' + cuk_list[cnt].cuk;						// "yrn:yahoo::::iaas:openstack:<cuk>"
+		var	is_openstack= (cuk_list[cnt].extra == keys.VALUE_OPENSTACK_V1);
+		var	top_key		= is_openstack ? keys.IAAS_OS_TOP_KEY : keys.IAAS_K8S_TOP_KEY;			// "yrn:yahoo::::iaas:{openstack|k8s}"
+		var	top_subkeys	= apiutil.getSafeArray(dkcobj_permanent.getSubkeys(top_key, true));		// get subkey list from yrn:yahoo::::iaas:{openstack|k8s}
+		var	cuk_key		= top_key + ':' + cuk_list[cnt].cuk;									// "yrn:yahoo::::iaas:{openstack|k8s}:<cuk>"
 		var	cuk_subkeys	= new Array();
 
 		// try to add cuk subkey to main subkey list
-		var	is_new_key	= apiutil.tryAddStringToArray(top_subkeys, cuk_key);					// add subkey cuk_list[cnt].cuk to yrn:yahoo::::iaas:openstack
+		var	is_new_key	= apiutil.tryAddStringToArray(top_subkeys, cuk_key);					// add subkey cuk_list[cnt].cuk to yrn:yahoo::::iaas:{openstack|k8s}
 		if(!is_new_key){
-			cuk_subkeys	= apiutil.getSafeArray(dkcobj_permanent.getSubkeys(cuk_key, true));		// get subkey list from yrn:yahoo::::iaas:openstack:<cuk>
+			cuk_subkeys	= apiutil.getSafeArray(dkcobj_permanent.getSubkeys(cuk_key, true));		// get subkey list from yrn:yahoo::::iaas:{openstack|k8s}:<cuk>
 		}
 
 		// add key to cuk_key subkey list
-		if(apiutil.tryAddStringToArray(cuk_subkeys, cuk_list[cnt].subkey)){						// add subkey cuk_list[cnt].subkey to yrn:yahoo::::iaas:openstack:<cuk>
+		if(apiutil.tryAddStringToArray(cuk_subkeys, cuk_list[cnt].subkey)){						// add subkey cuk_list[cnt].subkey to yrn:yahoo::::iaas:{openstack|k8s}:<cuk>
 			// need to add subkey
 			if(is_new_key){
-				if(!dkcobj_permanent.setValue(cuk_key, keys.VALUE_ENABLE)){						// set value enable(dummy) -> yrn:yahoo::::iaas:openstack:<cuk>
+				if(!dkcobj_permanent.setValue(cuk_key, keys.VALUE_ENABLE)){						// set value enable(dummy) -> yrn:yahoo::::iaas:{openstack|k8s}:<cuk>
 					r3logger.elog('could not set ' + keys.VALUE_ENABLE + ' value to ' + cuk_key + ', but continue...');
 					result = false;
 					continue;
 				}
 			}
-			if(!dkcobj_permanent.setSubkeys(cuk_key, cuk_subkeys)){								// set subkeys to yrn:yahoo::::iaas:openstack:<cuk>
+			if(!dkcobj_permanent.setSubkeys(cuk_key, cuk_subkeys)){								// set subkeys to yrn:yahoo::::iaas:{openstack|k8s}:<cuk>
 				r3logger.elog('could not set subkey list to ' + cuk_key + ', but continue...');
 				result = false;
 				continue;
 			}
 			if(is_new_key){
 				// make subkey
-				if(!dkcobj_permanent.setSubkeys(top_key, top_subkeys)){							// add subkey yrn:yahoo::::iaas:openstack:<cuk> -> yrn:yahoo::::iaas:openstack
+				if(!dkcobj_permanent.setSubkeys(top_key, top_subkeys)){							// add subkey yrn:yahoo::::iaas:{openstack|k8s}:<cuk> -> yrn:yahoo::::iaas:{openstack|k8s}
 					r3logger.elog('could not add subkey ' + cuk_key + ' to ' + top_key + ', but continue...');
 					result = false;
 					continue;
@@ -4599,7 +4932,7 @@ function rawAddIpsByCuk(dkcobj_permanent, cuk_list)
 // remove_under_role	:	flag for removing host under role(default false)
 //
 // [NOTE]
-// Current supports only OpenStack CUK, then extra is allowed only "openstack-auto-v1" now.
+// Current supports openStack and kubernetes CUK, then extra is allowed only 'openstack-auto-v1', 'k8s-auto-v1' now.
 //
 function rawRemoveIpsByCukEx(dkcobj_permanent, cuk, extra, host, remove_under_role)
 {
@@ -4613,12 +4946,6 @@ function rawRemoveIpsByCukEx(dkcobj_permanent, cuk, extra, host, remove_under_ro
 	}
 	if('boolean' !== typeof remove_under_role){
 		remove_under_role = false;
-	}
-	if(!apiutil.isSafeString(extra)){
-		extra = null;
-	}
-	if(!apiutil.isSafeString(extra)){
-		extra = null;
 	}
 	if(apiutil.isSafeEntity(host)){
 		if(apiutil.isSafeString(host)){
@@ -4637,17 +4964,16 @@ function rawRemoveIpsByCukEx(dkcobj_permanent, cuk, extra, host, remove_under_ro
 	//
 	var	keys		= r3keys();
 
-	// [TODO]
-	// Current checks extra only Openstack
-	//
-	if(extra != keys.VALUE_OPENSTACK_V1){
-		r3logger.dlog('extra is not ' + keys.VALUE_OPENSTACK_V1 + ', current is only support ' + keys.VALUE_OPENSTACK_V1);
+	// Current checks extra only openstack and kubernetes
+	if(!apiutil.isSafeString(extra) || (extra != keys.VALUE_OPENSTACK_V1 && extra != keys.VALUE_K8S_V1)){
+		r3logger.dlog('extra is not ' + keys.VALUE_OPENSTACK_V1 + ' nor ' + keys.VALUE_K8S_V1 + ', current is only support ' + keys.VALUE_OPENSTACK_V1 + ' and ' + keys.VALUE_K8S_V1);
 		return true;
 	}
+	var	is_openstack= (extra == keys.VALUE_OPENSTACK_V1);
 
 	//var iaas_key	= keys.IAAS_TOP_KEY;														// "yrn:yahoo::::iaas"
-	var	top_key		= keys.IAAS_OS_TOP_KEY;														// "yrn:yahoo::::iaas:openstack"
-	var	cuk_key		= top_key + ':' + cuk;														// "yrn:yahoo::::iaas:openstack:<cuk>"
+	var	top_key		= is_openstack ? keys.IAAS_OS_TOP_KEY : keys.IAAS_K8S_TOP_KEY;				// "yrn:yahoo::::iaas:{openstack|k8s}"
+	var	cuk_key		= top_key + ':' + cuk;														// "yrn:yahoo::::iaas:{openstack|k8s}:<cuk>"
 	var	result		= true;
 	var	top_subkeys;
 	var	cuk_subkeys;
@@ -4656,6 +4982,7 @@ function rawRemoveIpsByCukEx(dkcobj_permanent, cuk, extra, host, remove_under_ro
 	var	matches;
 	var	ip_value;
 	var	ip_key;
+	var	ip_key_value;
 	var	ip_subkeys;
 	var	cnt;
 
@@ -4664,8 +4991,8 @@ function rawRemoveIpsByCukEx(dkcobj_permanent, cuk, extra, host, remove_under_ro
 		// [NOTE]
 		// remove_under_role is true, try to remove keys under role/hosts/ip
 		//
-		// get subkey list from iaas:openstack:<cuk>
-		cuk_subkeys	= apiutil.getSafeArray(dkcobj_permanent.getSubkeys(cuk_key, true));			// get subkey list from yrn:yahoo::::iaas:openstack:<cuk>
+		// get subkey list from iaas:{openstack|k8s}:<cuk>
+		cuk_subkeys	= apiutil.getSafeArray(dkcobj_permanent.getSubkeys(cuk_key, true));			// get subkey list from yrn:yahoo::::iaas:{openstack|k8s}:<cuk>
 		ipptn		= new RegExp('^' + keys.MATCH_ANY_IP_PORT);									// regex = /^yrn:yahoo:(.*)::(.*):role:(.*)/hosts/ip/(.*) (.*) (.*)/
 
 		for(cnt = 0; cnt < cuk_subkeys.length; ++cnt){
@@ -4682,6 +5009,26 @@ function rawRemoveIpsByCukEx(dkcobj_permanent, cuk, extra, host, remove_under_ro
 			if(!apiutil.isEmptyArray(host) && !apiutil.findStringInArray(host, ip_value)){
 				r3logger.wlog('ip address(' + JSON.stringify(ip_value) + ') is not in remove host array(' + JSON.stringify(host) + ')');
 				continue;
+			}
+
+			// check ip key value for only kubernetes CUK
+			if(!is_openstack){
+				ip_key_value = dkcobj_permanent.getValue(cuk_subkeys[cnt], null, true, null);		// get value -> yrn:yahoo:<service>::<tenant>:role:<role>/hosts/ip/<address port cuk>
+				if(apiutil.isSafeString(ip_key_value) && apiutil.checkSimpleJSON(ip_key_value)){
+					ip_key_value = JSON.parse(ip_key_value);
+
+					// check cuk extra(type)
+					if(apiutil.isSafeString(ip_key_value.extra) && ip_key_value.extra == keys.VALUE_K8S_V1){
+						// a case of kubernetes, compare value
+						if(!rawCompareHostInfoValueAndKubernetesCuk(ip_key_value, cuk)){
+							r3logger.wlog('cuk subkey(' + cuk_subkeys[cnt] + ') is not as same as cuk value(' + JSON.stringify(cuk) + ').');
+							result = false;
+							continue;
+						}
+					}
+				}else{
+					// value is something wrong, thus we remove this wrong data.
+				}
 			}
 
 			// get role/hosts/ip subkeys
@@ -4710,26 +5057,26 @@ function rawRemoveIpsByCukEx(dkcobj_permanent, cuk, extra, host, remove_under_ro
 
 	// check and remove ip address path subkey from cuk key
 	if(apiutil.isEmptyArray(host)){
-		// remove cuk from subkey list in openstack
-		top_subkeys	= apiutil.getSafeArray(dkcobj_permanent.getSubkeys(top_key, true));			// get subkey list from yrn:yahoo::::iaas:openstack
+		// remove cuk from subkey list in openstack or k8s
+		top_subkeys	= apiutil.getSafeArray(dkcobj_permanent.getSubkeys(top_key, true));			// get subkey list from yrn:yahoo::::iaas:{openstack|k8s}
 		if(apiutil.isEmptyArray(top_subkeys) || !apiutil.removeStringFromArray(top_subkeys, cuk_key)){
 			r3logger.dlog(top_key + ' does not have ' + cuk_key + ' subkey');
 		}else{
 			// set new subkey list
-			if(!dkcobj_permanent.setSubkeys(top_key, top_subkeys)){								// reset new cuk list -> yrn:yahoo::::iaas:openstack
+			if(!dkcobj_permanent.setSubkeys(top_key, top_subkeys)){								// reset new cuk list -> yrn:yahoo::::iaas:{openstack|k8s}
 				r3logger.dlog('could not remove subkey ' + cuk + ' from ' + top_key + ', but continue...');
 				result = false;
 			}
 		}
 
 		// remove cuk
-		if(!dkcobj_permanent.remove(cuk_key, false)){											// remove "yrn:yahoo::::iaas:openstack:<cuk>"
+		if(!dkcobj_permanent.remove(cuk_key, false)){											// remove "yrn:yahoo::::iaas:{openstack|k8s}:<cuk>"
 			r3logger.elog('could not remove ' + cuk_key + 'key, probably it is not existed.');
 			result = false;
 		}
 	}else{
 		// remove target ip address from cuk's subkey list
-		cuk_subkeys	= apiutil.getSafeArray(dkcobj_permanent.getSubkeys(cuk_key, true));			// get subkey list from yrn:yahoo::::iaas:openstack:<cuk>
+		cuk_subkeys	= apiutil.getSafeArray(dkcobj_permanent.getSubkeys(cuk_key, true));			// get subkey list from yrn:yahoo::::iaas:{openstack|k8s}:<cuk>
 		ipptn		= new RegExp('^' + keys.MATCH_ANY_IP_PORT);									// regex = /^yrn:yahoo:(.*)::(.*):role:(.*)/hosts/ip/(.*) (.*) (.*)/
 		new_subkeys	= new Array();
 		for(cnt = 0; cnt < cuk_subkeys.length; ++cnt){
@@ -4750,25 +5097,25 @@ function rawRemoveIpsByCukEx(dkcobj_permanent, cuk, extra, host, remove_under_ro
 		}
 
 		if(apiutil.isEmptyArray(new_subkeys)){
-			// remove cuk from subkey list in openstack
-			top_subkeys	= apiutil.getSafeArray(dkcobj_permanent.getSubkeys(top_key, true));		// get subkey list from yrn:yahoo::::iaas:openstack
+			// remove cuk from subkey list in openstack or k8s
+			top_subkeys	= apiutil.getSafeArray(dkcobj_permanent.getSubkeys(top_key, true));		// get subkey list from yrn:yahoo::::iaas:{openstack|k8s}
 			if(apiutil.isEmptyArray(top_subkeys) || !apiutil.removeStringFromArray(top_subkeys, cuk_key)){
 				r3logger.dlog(top_key + ' does not have ' + cuk_key + ' subkey');
 			}else{
-				// set new subkey list to openstack
-				if(!dkcobj_permanent.setSubkeys(top_key, top_subkeys)){							// reset new cuk list -> yrn:yahoo::::iaas:openstack
+				// set new subkey list to openstack or k8s
+				if(!dkcobj_permanent.setSubkeys(top_key, top_subkeys)){							// reset new cuk list -> yrn:yahoo::::iaas:{openstack|k8s}
 					r3logger.dlog('could not remove subkey ' + cuk + ' from ' + top_key + ', but continue...');
 					result = false;
 				}
 			}
 			// remove cuk
-			if(!dkcobj_permanent.remove(cuk_key, false)){										// remove "yrn:yahoo::::iaas:openstack:<cuk>"
+			if(!dkcobj_permanent.remove(cuk_key, false)){										// remove "yrn:yahoo::::iaas:{openstack|k8s}:<cuk>"
 				r3logger.elog('could not remove ' + cuk_key + 'key, probably it is not existed.');
 				result = false;
 			}
 		}else{
 			// update new subkey list to cuk
-			if(!dkcobj_permanent.setSubkeys(cuk_key, new_subkeys)){								// reset new subkey -> yrn:yahoo::::iaas:openstack:<cuk>
+			if(!dkcobj_permanent.setSubkeys(cuk_key, new_subkeys)){								// reset new subkey -> yrn:yahoo::::iaas:{openstack|k8s}:<cuk>
 				r3logger.dlog('could not remove subkey ' + cuk + ' from ' + top_key + ', but continue...');
 				result = false;
 			}
@@ -4783,7 +5130,7 @@ function rawRemoveIpsByCukEx(dkcobj_permanent, cuk, extra, host, remove_under_ro
 // tgkey				:	yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts/{name or ip}/<address port cuk>
 //
 // [NOTE]
-// Current supports only OpenStack CUK, then extra is allowed only "openstack-auto-v1" now.
+// Current supports openStack and kubernetes CUK, then extra is allowed only 'openstack-auto-v1', 'k8s-auto-v1' now.
 //
 function rawRemoveIpsSubkeyByCuk(dkcobj_permanent, tgkey)
 {
@@ -4800,33 +5147,31 @@ function rawRemoveIpsSubkeyByCuk(dkcobj_permanent, tgkey)
 	// keys
 	//
 	var	keys		= r3keys();
-	//var iaas_key	= keys.IAAS_TOP_KEY;													// "yrn:yahoo::::iaas"
-	var	top_key		= keys.IAAS_OS_TOP_KEY;													// "yrn:yahoo::::iaas:openstack"
 
 	// get tgkey data
-	var	value = dkcobj_permanent.getValue(tgkey, null, true, null);							// get value -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts/{name or ip}/<address port cuk>
-	if(!apiutil.isSafeString(value) || !apiutil.checkSimpleJSON(value)){
+	var	value		= dkcobj_permanent.getValue(tgkey, null, true, null);					// get value -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts/{name or ip}/<address port cuk>
+	value			= apiutil.parseJSON(value);
+	if(!apiutil.isSafeEntity(value)){
 		r3logger.dlog('tgkey(' + tgkey + ') does not have correct ip/hostname key value');
 		return true;
 	}
-	value = JSON.parse(value);
 
 	if(!apiutil.isSafeString(value.cuk)){
 		r3logger.dlog('tgkey(' + tgkey + ') does  not have cuk');
 		return true;
 	}
-	var	cuk_key		= top_key + ':' + value.cuk;											// "yrn:yahoo::::iaas:openstack:<cuk>"
 
-	// [TODO]
-	// Current checks extra only Openstack
-	//
-	if(!apiutil.isSafeString(value.extra) || value.extra != keys.VALUE_OPENSTACK_V1){
-		r3logger.dlog('extra is not ' + keys.VALUE_OPENSTACK_V1 + ', current is only support ' + keys.VALUE_OPENSTACK_V1);
+	// Current checks extra only openstack and kubernetes
+	if(!apiutil.isSafeString(value.extra) || (value.extra != keys.VALUE_OPENSTACK_V1 && value.extra != keys.VALUE_K8S_V1)){
+		r3logger.dlog('extra is not ' + keys.VALUE_OPENSTACK_V1 + ' nor ' + keys.VALUE_K8S_V1 + ', current is only support ' + keys.VALUE_OPENSTACK_V1 + ' and ' + keys.VALUE_K8S_V1);
 		return true;
 	}
+	var	is_openstack= (value.extra == keys.VALUE_OPENSTACK_V1);
+	var	top_key		= is_openstack ? keys.IAAS_OS_TOP_KEY : keys.IAAS_K8S_TOP_KEY;			// "yrn:yahoo::::iaas:{openstack|k8s}"
+	var	cuk_key		= top_key + ':' + value.cuk;											// "yrn:yahoo::::iaas:{openstack|k8s}:<cuk>"
 
 	// remove tgkey from subkey list
-	var	cuk_subkeys	= apiutil.getSafeArray(dkcobj_permanent.getSubkeys(cuk_key, true));		// get subkey list from yrn:yahoo::::iaas:openstack:<cuk>
+	var	cuk_subkeys	= apiutil.getSafeArray(dkcobj_permanent.getSubkeys(cuk_key, true));		// get subkey list from yrn:yahoo::::iaas:{openstack|k8s}:<cuk>
 	if(apiutil.isEmptyArray(cuk_subkeys) || !apiutil.removeStringFromArray(cuk_subkeys, tgkey)){
 		r3logger.dlog('cuk key(' + cuk_key + ') already does not have ' + tgkey + ' subkey.');
 		return true;
@@ -4835,26 +5180,26 @@ function rawRemoveIpsSubkeyByCuk(dkcobj_permanent, tgkey)
 	// reset
 	if(apiutil.isEmptyArray(cuk_subkeys)){
 		// subkey list is empty, then remove cuk key
-		var	top_subkeys = apiutil.getSafeArray(dkcobj_permanent.getSubkeys(top_key, true));	// get subkey list from yrn:yahoo::::iaas:openstack
+		var	top_subkeys = apiutil.getSafeArray(dkcobj_permanent.getSubkeys(top_key, true));	// get subkey list from yrn:yahoo::::iaas:{openstack|k8s}
 
 		// remove cuk key from top's subkey list
 		if(apiutil.isEmptyArray(top_subkeys) || !apiutil.removeStringFromArray(top_subkeys, cuk_key)){
-			r3logger.dlog('openstack key(' + top_key + ') already does not have ' + cuk_key + ' subkey.');
+			r3logger.dlog('openstack or k8s key(' + top_key + ') already does not have ' + cuk_key + ' subkey.');
 		}else{
 			// reset top's subkey list
-			if(!dkcobj_permanent.setSubkeys(top_key, top_subkeys)){							// reset new subkey list -> yrn:yahoo::::iaas:openstack
-				r3logger.dlog('could not set new subkey list to openstack key(' + top_key + ')');
+			if(!dkcobj_permanent.setSubkeys(top_key, top_subkeys)){							// reset new subkey list -> yrn:yahoo::::iaas:{openstack|k8s}
+				r3logger.dlog('could not set new subkey list to openstack or k8s key(' + top_key + ')');
 			}
 		}
 
 		// remove cuk key
-		if(!dkcobj_permanent.remove(cuk_key, false)){										// remove yrn:yahoo::::iaas:openstack:<cuk>
+		if(!dkcobj_permanent.remove(cuk_key, false)){										// remove yrn:yahoo::::iaas:{openstack|k8s}:<cuk>
 			r3logger.elog('could not remove ' + cuk_key + ' key, probably it is not existed. thus continue...');
 		}
 
 	}else{
 		// reset subkey list
-		if(!dkcobj_permanent.setSubkeys(cuk_key, cuk_subkeys)){								// reset new subkey list -> yrn:yahoo::::iaas:openstack:<cuk>
+		if(!dkcobj_permanent.setSubkeys(cuk_key, cuk_subkeys)){								// reset new subkey list -> yrn:yahoo::::iaas:{openstack|k8s}:<cuk>
 			r3logger.dlog('could not set new subkey list to cuk key(' + cuk_key + ')');
 			return false;
 		}
@@ -4867,23 +5212,31 @@ function rawRemoveIpsSubkeyByCuk(dkcobj_permanent, tgkey)
 // remove IP address by CUK raw function
 //---------------------------------------------------------
 // cuk				:	CUK key name
-// extra			:	extra value
 // host				:	remove host(ip) string or string array(undefined or null means all)
 // remove_under_role:	flag for removing host under role(default false)
 //
 // [NOTE]
-// Current supports only OpenStack CUK, then extra is allowed only "openstack-auto-v1" now.
+// Current supports openStack and kubernetes CUK, then extra is allowed only 'openstack-auto-v1', 'k8s-auto-v1' now.
 //
-function rawRemoveIpsByCuk(cuk, extra, host, remove_under_role)
+function rawRemoveIpsByCuk(cuk, host, remove_under_role)
 {
 	var	resobj = {result: true, message: null};
 
-	if(!apiutil.isSafeString(cuk, extra)){
+	if(!apiutil.isSafeString(cuk)){
 		resobj.result	= false;
-		resobj.message	= 'some parameters are wrong : cuk=' + JSON.stringify(cuk) + ', extra=' + JSON.stringify(extra);
+		resobj.message	= 'some parameters are wrong : cuk=' + JSON.stringify(cuk);
 		r3logger.elog(resobj.message);
 		return resobj;
 	}
+	var	keys	= r3keys();
+	var	extra	= rawGetExtraFromCuk(cuk);
+	if(extra != keys.VALUE_OPENSTACK_V1 && extra != keys.VALUE_K8S_V1){
+		resobj.result	= false;
+		resobj.message	= 'some parameters are wrong : cuk=' + JSON.stringify(cuk);
+		r3logger.elog(resobj.message);
+		return resobj;
+	}
+
 	if('boolean' !== typeof remove_under_role){
 		remove_under_role = false;
 	}
@@ -4915,15 +5268,17 @@ function rawRemoveIpsByCuk(cuk, extra, host, remove_under_role)
 //---------------------------------------------------------
 // Get all ip address with etc data which are related to CUK
 //
+// extra			:	extra value('openstack-auto-v1' or 'k8s-auto-v1')
+//
 // Result:
 // {								-> Always return object
 //		error:						-> null or Error object(if error)
 //		data: [						-> data array includes ip address etc
 //			{
-//				ipaddr:	ip,			-> ip address string
+//				ip:		ip,			-> ip address string
 //				port:	port,		-> port number or *
 //				cuk:	cuk,		-> cuk string
-//				extra:	string		-> always 'openstack-auto-v1'
+//				extra:	string		-> 'openstack-auto-v1' or 'k8s-auto-v1'
 //				key:	string		-> this ip address yrn full path
 //				alive: 	true		-> always true
 //			},
@@ -4934,13 +5289,23 @@ function rawRemoveIpsByCuk(cuk, extra, host, remove_under_role)
 //	}
 //
 // [NOTE]
-// Current, this function supports only openstack.
+// Current, this function supports only openstack and kubernetes.
 // This function operates sequentially for k2hdkc handle, and this
 // function calling process does not work in the main process.
 //
-function rawGetAllIpDatasByCuk()
+function rawGetAllIpDatasByCuk(extra)
 {
 	var	result = {error: null, data: null};
+
+	var	keys = r3keys();
+
+	// Current checks extra only openstack and kubernetes
+	if(!apiutil.isSafeString(extra) || (extra != keys.VALUE_OPENSTACK_V1 && extra != keys.VALUE_K8S_V1)){
+		result.error = new Error('extra(' + JSON.stringify(extra) + ') is something wrong.');
+		r3logger.elog(result.error.message);
+		return result;
+	}
+	var	is_openstack = (extra == keys.VALUE_OPENSTACK_V1);
 
 	//
 	// K2HDKC
@@ -4956,37 +5321,38 @@ function rawGetAllIpDatasByCuk()
 	//
 	// keys
 	//
-	var	keys		= r3keys();
 	//var iaas_key	= keys.IAAS_TOP_KEY;														// "yrn:yahoo::::iaas"
-	var	top_key		= keys.IAAS_OS_TOP_KEY;														// "yrn:yahoo::::iaas:openstack"
-	var	osptn		= new RegExp('^' + keys.MATCH_ANY_IAAS_OS);									// regex = /^yrn:yahoo::::iaas:openstack:(.*)/
+	var	top_key		= is_openstack ? keys.IAAS_OS_TOP_KEY : keys.IAAS_K8S_TOP_KEY;				// "yrn:yahoo::::iaas:{openstack|k8s}"
+	var	iaasmatch	= is_openstack ? keys.MATCH_ANY_IAAS_OS : keys.MATCH_ANY_IAAS_K8S;			// 
+	var	iaasptn		= new RegExp('^' + iaasmatch);												// regex = /^yrn:yahoo::::iaas:{openstack|k8s}:(.*)/
 	var	ipptn		= new RegExp('^' + keys.MATCH_ANY_IP_PORT);									// regex = /^yrn:yahoo:(.*)::(.*):role:(.*)/hosts/ip/(.*) (.*) (.*)/
 	result.data		= new Array();
 
-	// Get subkey list under iaas:openstack
-	var	top_subkeys	= apiutil.getSafeArray(dkcobj.getSubkeys(top_key, true));					// get subkey list from yrn:yahoo::::iaas:openstack
+	// Get subkey list under iaas:{openstack|k8s}
+	var	top_subkeys	= apiutil.getSafeArray(dkcobj.getSubkeys(top_key, true));					// get subkey list from yrn:yahoo::::iaas:{openstack|k8s}
+
 	for(var cnt = 0; cnt < top_subkeys.length; ++cnt){
 		if(!apiutil.isSafeString(top_subkeys[cnt])){
 			r3logger.wlog('subkey path' + JSON.stringify(top_subkeys[cnt]) + ' in ' + top_key + ' is something wrong.');
 			continue;
 		}
 		// check & parse cuk string
-		var	cukmatches	= top_subkeys[cnt].match(osptn);										// check key is under "yrn:yahoo::::iaas:openstack"
+		var	cukmatches	= top_subkeys[cnt].match(iaasptn);										// check key is under "yrn:yahoo::::iaas:{openstack|k8s}"
 		if(apiutil.isEmptyArray(cukmatches) || cukmatches.length < 2 || !apiutil.isSafeString(cukmatches[1])){
 			r3logger.dlog('subkey path' + JSON.stringify(top_subkeys[cnt]) + ' in ' + top_key + ' is not matched ' + keys.MATCH_ANY_IAAS_OS);
 			continue;
 		}
 		var	cuk = cukmatches[1];
 
-		// Get subkey list under iaas:openstack:<cuk>
-		var	cuk_subkeys = apiutil.getSafeArray(dkcobj.getSubkeys(top_subkeys[cnt], true));		// get subkey list from yrn:yahoo::::iaas:openstack:<cuk>
+		// Get subkey list under iaas:{openstack|k8s}:<cuk>
+		var	cuk_subkeys = apiutil.getSafeArray(dkcobj.getSubkeys(top_subkeys[cnt], true));		// get subkey list from yrn:yahoo::::iaas:{openstack|k8s}:<cuk>
 		for(var cnt2 = 0; cnt2 < cuk_subkeys.length; ++cnt2){
 			if(!apiutil.isSafeString(cuk_subkeys[cnt2])){
 				r3logger.wlog('subkey path' + JSON.stringify(cuk_subkeys[cnt2]) + ' in ' + top_subkeys[cnt] + ' is something wrong.');
 				continue;
 			}
 			// check and parse ip string
-			var	ipmatches = cuk_subkeys[cnt2].match(ipptn);
+			var	ipmatches = cuk_subkeys[cnt2].match(ipptn);										// check yrn:yahoo:(.*)::(.*):role:(.*)/hosts/ip/(.*) (.*) (.*)
 			if(apiutil.isEmptyArray(ipmatches) || ipmatches.length < 7 || !apiutil.isSafeString(ipmatches[4]) || !apiutil.isSafeString(ipmatches[5])){
 				r3logger.dlog('ip subkey (' + JSON.stringify(cuk_subkeys[cnt2]) + ') in ' +  top_subkeys[cnt] +' is not matched ' + keys.MATCH_ANY_IP_PORT);
 				continue;
@@ -5003,24 +5369,34 @@ function rawGetAllIpDatasByCuk()
 				continue;
 			}
 			ipvalue = JSON.parse(ipvalue);
+
 			// check extra in value
-			if(!apiutil.isSafeString(ipvalue.extra) || ipvalue.extra != keys.VALUE_OPENSTACK_V1){
-				r3logger.dlog('ip subkey (' + JSON.stringify(cuk_subkeys[cnt2]) + ') in ' +  top_subkeys[cnt] +' does not have ' + keys.VALUE_OPENSTACK_V1 + ' extra data.');
+			if(!apiutil.isSafeString(ipvalue.extra) || (is_openstack && ipvalue.extra != keys.VALUE_OPENSTACK_V1) || (!is_openstack && ipvalue.extra != keys.VALUE_K8S_V1)){
+				r3logger.dlog('ip subkey (' + JSON.stringify(cuk_subkeys[cnt2]) + ') in ' +  top_subkeys[cnt] +' does not have ' + (is_openstack ? keys.VALUE_OPENSTACK_V1 : keys.VALUE_K8S_V1) + ' extra data.');
 				continue;
 			}
-			var	ip		= ipmatches[4];
-			var	port	= ipmatches[5];
-			var	extra	= ipvalue.extra;
 
 			// Add ip address data to result.data
-			result.data.push({
-				ipaddr:		ip,
-				port:		port,
-				cuk:		cuk,
-				extra:		extra,
-				key:		cuk_subkeys[cnt2],
-				alive: 		true
-			});
+			var	host_info	= {};
+			host_info.ip	= ipmatches[4];
+			host_info.port	= ipmatches[5];
+			host_info.cuk	= cuk;
+			host_info.extra	= ipvalue.extra;
+			host_info.key	= cuk_subkeys[cnt2];
+			host_info.alive	= true;
+
+			if(!is_openstack){
+				host_info[keys.K8S_NAMESPACE_INCUK_KEY]		= apiutil.getSafeString(ipvalue[keys.K8S_NAMESPACE_INCUK_KEY]);
+				host_info[keys.K8S_SA_INCUK_KEY]			= apiutil.getSafeString(ipvalue[keys.K8S_SA_INCUK_KEY]);
+				host_info[keys.K8S_NODENAME_INCUK_KEY]		= apiutil.getSafeString(ipvalue[keys.K8S_NODENAME_INCUK_KEY]);
+				host_info[keys.K8S_NODEIP_INCUK_KEY]		= apiutil.getSafeString(ipvalue[keys.K8S_NODEIP_INCUK_KEY]);
+				host_info[keys.K8S_PODNAME_INCUK_KEY]		= apiutil.getSafeString(ipvalue[keys.K8S_PODNAME_INCUK_KEY]);
+				host_info[keys.K8S_PODID_INCUK_KEY]			= apiutil.getSafeString(ipvalue[keys.K8S_PODID_INCUK_KEY]);
+				host_info[keys.K8S_PODIP_INCUK_KEY]			= apiutil.getSafeString(ipvalue[keys.K8S_PODIP_INCUK_KEY]);
+				host_info[keys.K8S_CONTAINERID_INCUK_KEY]	= apiutil.getSafeString(ipvalue[keys.K8S_CONTAINERID_INCUK_KEY]);
+				host_info[keys.K8S_RAND_INCUK_KEY]			= apiutil.getSafeString(ipvalue[keys.K8S_RAND_INCUK_KEY]);
+			}
+			result.data.push(host_info);
 		}
 	}
 
@@ -5037,11 +5413,11 @@ function rawGetAllIpDatasByCuk()
 // ipdatas:				Array of ip address and etc
 //							[
 //								{
-//									ipaddr:	ip,			-> ip address string
+//									ip:		ip,			-> ip address string
 //									cuk:	cuk,		-> cuk string
 //									port:	port,		-> port number or *
 //									cuk:	cuk,		-> cuk string
-//									extra:	string		-> 'openstack-auto-v1' or etc
+//									extra:	string		-> 'openstack-auto-v1', 'k8s-auto-v1' or etc
 //									key:	string		-> this ip address yrn full path
 //									alive: 	boolean		-> true or false
 //								},
@@ -5056,7 +5432,7 @@ function rawGetAllIpDatasByCuk()
 //						something error occurred
 //
 // [NOTE]
-// Current, this function supports only openstack.
+// Current, this function supports only openstack and kubernetes.
 // This function operates sequentially for k2hdkc handle, and this
 // function calling process does not work in the main process.
 //
@@ -5099,11 +5475,12 @@ function rawRemoveIpAddressWithCuk(ipdatas, pendingsec, logger)
 	for(var cnt = 0; cnt < ipdatas.length; ++cnt){
 		// check
 		if(	!apiutil.isSafeEntity(ipdatas[cnt])						||							// must be object
-			!apiutil.isSafeString(ipdatas[cnt].ipaddr)				||							// must be string
+			!apiutil.isSafeString(ipdatas[cnt].ip)					||							// must be string
 			(isNaN(ipdatas[cnt].port) && ipdatas[cnt].port != '*')	||							// must be number or '*'
 			!apiutil.isSafeString(ipdatas[cnt].cuk)					||							// must be string
-			!apiutil.isSafeString(ipdatas[cnt].extra)				||							// must be string and 'openstack-auto-v1'
-			ipdatas[cnt].extra != keys.VALUE_OPENSTACK_V1			||							// 
+			!apiutil.isSafeString(ipdatas[cnt].extra)				||							// must be string
+			(	ipdatas[cnt].extra != keys.VALUE_OPENSTACK_V1	&&								// must be 'openstack-auto-v1' or 'k8s-auto-v1'
+				ipdatas[cnt].extra != keys.VALUE_K8S_V1			)	||
 			!apiutil.isSafeString(ipdatas[cnt].key)					||							// must be string
 			!apiutil.isSafeEntity(ipdatas[cnt].alive)				||							// must be boolean
 			'boolean' != typeof ipdatas[cnt].alive					)							// 
@@ -5149,7 +5526,7 @@ function rawRemoveIpAddressWithCuk(ipdatas, pendingsec, logger)
 					// over pending time, thus remove this
 					r3logger.dlog('IP address is not alive and over pending time, thus remove No.' + cnt.toString() + ' element ip key(' + ipdatas[cnt].key + ')');
 
-					if(!rawRemoveIpsByCukEx(dkcobj, ipdatas[cnt].cuk, ipdatas[cnt].extra, ipdatas[cnt].ipaddr, true)){
+					if(!rawRemoveIpsByCukEx(dkcobj, ipdatas[cnt].cuk, ipdatas[cnt].extra, ipdatas[cnt].ip, true)){
 						r3logger.elog('could not remove No.' + cnt.toString() + ' element ip key(' + ipdatas[cnt].key + '), but continue...');
 						errorKeys.push('remove ip for (' + ipdatas[cnt].key + ')');
 						logger('ERROR:REMOVE - [' + ipdatas[cnt].key + ']');
@@ -5238,7 +5615,7 @@ function rawGetRoleHostLists(dkcobj_permanent, role_key, is_expand, base_role_to
 		r3logger.elog('parameter dkcobj_permanent is not object or not permanent');
 		return null;
 	}
-	if(!apiutil.isSafeStrings(role_key)){
+	if(!apiutil.isSafeString(role_key)){
 		r3logger.elog('some parameters are wrong : role_key=' + JSON.stringify(role_key));
 		return null;
 	}
@@ -5256,6 +5633,7 @@ function rawGetRoleHostLists(dkcobj_permanent, role_key, is_expand, base_role_to
 	var	hosts_key		= role_key	+ '/' + keys.HOSTS_KW;									// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts"
 	var	name_key		= hosts_key	+ '/' + keys.HOSTS_NAME_KW;								// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts/name"
 	var	ip_key			= hosts_key	+ '/' + keys.HOSTS_IP_KW;								// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts/ip"
+	var	tokens_key		= role_key	+ '/' + keys.ROLE_TOKEN_KW;								// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/tokens"
 	var	alias_key		= role_key	+ '/' + keys.ALIAS_KW;									// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/@"
 
 	var	resultobj		= { 'normal': { 'hostnames': [], 'ips': [] }, 'all': { 'hostnames': [], 'ips': [] } };
@@ -5284,7 +5662,7 @@ function rawGetRoleHostLists(dkcobj_permanent, role_key, is_expand, base_role_to
 	// get hostnames and ips from aliases when role is the direct base of base_role_top.
 	if(is_expand && 0 === role_key.indexOf(base_role_top)){
 		var	aliasvalue = dkcobj_permanent.getValue(alias_key, null, true, null);
-		if(apiutil.isSafeEntity(aliasvalue)){
+		if(apiutil.checkSimpleJSON(aliasvalue)){
 			aliasvalue = JSON.parse(aliasvalue);
 			if(!apiutil.isEmptyArray(aliasvalue)){
 				for(cnt = 0; cnt < aliasvalue.length; ++cnt){
@@ -5315,7 +5693,7 @@ function rawGetRoleHostLists(dkcobj_permanent, role_key, is_expand, base_role_to
 			// matches[5] ---> port number
 			// matches[6] ---> container unique key(now does not check this value)
 			//
-			if(keys.VALUE_ANY_PORT === matches[5] || (!isNaN(matches[5]) && 0 == parseInt(matches[5]))){
+			if(rawIsPortAny(matches[5])){
 				hostvalue = matches[4];															// "<hostname>"
 			}else if(!isNaN(matches[5])){
 				hostvalue = matches[4] + keys.VALUE_HOST_REGSEP + matches[5];					// "<hostname>:<port>"
@@ -5357,7 +5735,7 @@ function rawGetRoleHostLists(dkcobj_permanent, role_key, is_expand, base_role_to
 			// matches[5] ---> port number
 			// matches[6] ---> container unique key(now does not check this value)
 			//
-			if(keys.VALUE_ANY_PORT === matches[5] || (!isNaN(matches[5]) && 0 == parseInt(matches[5]))){
+			if(rawIsPortAny(matches[5])){
 				hostvalue = matches[4];															// "<ip address>"
 			}else if(!isNaN(matches[5])){
 				hostvalue = matches[4] + keys.VALUE_HOST_REGSEP + matches[5];					// "<ip address>:<port>"
@@ -5393,6 +5771,7 @@ function rawGetRoleHostLists(dkcobj_permanent, role_key, is_expand, base_role_to
 				reference_key	=== subkeylist[cnt]		||
 				hosts_key		=== subkeylist[cnt]		||
 				id_key			=== subkeylist[cnt]		||
+				tokens_key		=== subkeylist[cnt]		||
 				alias_key		=== subkeylist[cnt]		)
 			{
 				continue;
@@ -5418,7 +5797,7 @@ function rawGetRoleHostLists(dkcobj_permanent, role_key, is_expand, base_role_to
 // ip				:	ip address string or array
 // port				:	port number(0 means any)
 // cuk				:	container unique key(null(undefined) is any)
-// extra			:	extra data(undefined and null means any, string is perfect matching, RegExp object is regular expression)
+// is_strict		:	check for exact mate of parameters such as port/cuk
 //
 // return			:	null(not found) or found hostname(ip) following element array
 //						{
@@ -5444,7 +5823,7 @@ function rawGetRoleHostLists(dkcobj_permanent, role_key, is_expand, base_role_to
 // the host is added to tenant role under service.
 // The service name can be allowed undefined and null.
 //
-function rawFindHost(tenant, service, role, hostname, ip, port, cuk, extra)
+function rawFindHost(tenant, service, role, hostname, ip, port, cuk, is_strict)
 {
 	var	resobj	= {result: true, message: null};
 
@@ -5470,6 +5849,9 @@ function rawFindHost(tenant, service, role, hostname, ip, port, cuk, extra)
 		service			= service.toLowerCase();
 	}else{
 		service			= null;
+	}
+	if('boolean' != typeof is_strict){
+		is_strict		= false;
 	}
 
 	// check role name is only name or full yrn path
@@ -5513,7 +5895,7 @@ function rawFindHost(tenant, service, role, hostname, ip, port, cuk, extra)
 	}
 
 	// find
-	var	result		= rawFindRoleHost(dkcobj, role_key, hostname, ip, port, cuk, extra);
+	var	result		= rawFindRoleHost(dkcobj, role_key, hostname, ip, port, cuk, is_strict);
 	if(apiutil.isEmptyArray(result)){
 		resobj.result	= false;
 		resobj.message	= 'Not found any host by hostname(' + JSON.stringify(hostname) + ') and ip(' + JSON.stringify(ip) + ') and port(' + JSON.stringify(port) + ')';
@@ -5532,7 +5914,7 @@ function rawFindHost(tenant, service, role, hostname, ip, port, cuk, extra)
 // ip				:	ip address string or array
 // port				:	port number(0, undefined, null means any)
 // cuk				:	container unique key(undefined, null means any)
-// extra			:	extra data(undefined and null means any, string is perfect matching, RegExp object is regular expression)
+// is_strict		:	check for exact mate of parameters such as port/cuk
 // base_role_top	:	The base_role_top is the top path of the roll path that started getting host list.
 //						For example, if role_key is an alias for another role, base_role_top will indicate
 //						a different top path.
@@ -5555,7 +5937,7 @@ function rawFindHost(tenant, service, role, hostname, ip, port, cuk, extra)
 // If port is any(0), this function check all port data in hostname/ip.
 // If there is same hostname or ip with any port, it matches regardless of the value of port.
 //
-function rawFindRoleHost(dkcobj_permanent, role_key, hostname, ip, port, cuk, extra, base_role_top)
+function rawFindRoleHost(dkcobj_permanent, role_key, hostname, ip, port, cuk, is_strict, base_role_top)
 {
 	if(!(dkcobj_permanent instanceof Object) || !dkcobj_permanent.isPermanent()){
 		r3logger.elog('parameter dkcobj_permanent is not object or not permanent');
@@ -5578,9 +5960,8 @@ function rawFindRoleHost(dkcobj_permanent, role_key, hostname, ip, port, cuk, ex
 	if(!apiutil.isSafeString(cuk)){
 		cuk = null;
 	}
-	if(apiutil.isSafeEntity(extra) && !apiutil.isSafeString(extra) && !(extra instanceof RegExp)){
-		r3logger.elog('extra(' + JSON.stringify(extra) + ') parameter is wrong.');
-		return null;
+	if('boolean' != typeof is_strict){
+		is_strict = false;
 	}
 
 	// get tenant/service
@@ -5617,6 +5998,7 @@ function rawFindRoleHost(dkcobj_permanent, role_key, hostname, ip, port, cuk, ex
 	var	hosts_key		= role_key	+ '/' + keys.HOSTS_KW;									// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts"
 	var	name_key		= hosts_key	+ '/' + keys.HOSTS_NAME_KW;								// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts/name"
 	var	ip_key			= hosts_key	+ '/' + keys.HOSTS_IP_KW;								// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts/ip"
+	var	tokens_key		= role_key	+ '/' + keys.ROLE_TOKEN_KW;								// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/tokens"
 	var	alias_key		= role_key	+ '/' + keys.ALIAS_KW;									// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/@"
 
 	var	subkeylist;
@@ -5626,7 +6008,7 @@ function rawFindRoleHost(dkcobj_permanent, role_key, hostname, ip, port, cuk, ex
 	// check under hostname key
 	if(apiutil.isSafeString(hostname) || !apiutil.isEmptyArray(hostname)){
 		subkeylist	= dkcobj_permanent.getSubkeys(name_key, true);
-		tmp_result	= rawMatchHost(dkcobj_permanent, subkeylist, hostname, port, cuk, extra);
+		tmp_result	= rawMatchHost(dkcobj_permanent, subkeylist, hostname, port, cuk, is_strict);
 		if(!apiutil.isEmptyArray(tmp_result)){
 			foud_hosts = foud_hosts.concat(tmp_result);
 		}
@@ -5634,7 +6016,7 @@ function rawFindRoleHost(dkcobj_permanent, role_key, hostname, ip, port, cuk, ex
 	// check under ip key
 	if(apiutil.isSafeString(ip) || !apiutil.isEmptyArray(ip)){
 		subkeylist	= dkcobj_permanent.getSubkeys(ip_key, true);
-		tmp_result	= rawMatchHost(dkcobj_permanent, subkeylist, ip, port, cuk, extra);
+		tmp_result	= rawMatchHost(dkcobj_permanent, subkeylist, ip, port, cuk, is_strict);
 		if(!apiutil.isEmptyArray(tmp_result)){
 			foud_hosts = foud_hosts.concat(tmp_result);
 		}
@@ -5648,13 +6030,14 @@ function rawFindRoleHost(dkcobj_permanent, role_key, hostname, ip, port, cuk, ex
 			reference_key	=== subkeylist[cnt]		||
 			hosts_key		=== subkeylist[cnt]		||
 			id_key			=== subkeylist[cnt]		||
+			tokens_key		=== subkeylist[cnt]		||
 			alias_key		=== subkeylist[cnt]		)
 		{
 			continue;
 		}
 
 		// reentrant
-		tmp_result	= rawFindRoleHost(dkcobj_permanent, subkeylist[cnt], hostname, ip, port, cuk, extra, base_role_top);
+		tmp_result	= rawFindRoleHost(dkcobj_permanent, subkeylist[cnt], hostname, ip, port, cuk, is_strict, base_role_top);
 		if(!apiutil.isEmptyArray(tmp_result)){
 			// found host in sub roles
 			foud_hosts = foud_hosts.concat(tmp_result);
@@ -5668,14 +6051,13 @@ function rawFindRoleHost(dkcobj_permanent, role_key, hostname, ip, port, cuk, ex
 	return foud_hosts;
 }
 
-//
 // Utility for matching hostname(s) or ip and port in string array
 //
 // key_array	:	key string array, these keys are subkey list under hostname/ip key.
 // target		:	hostname or ip address string, or array
 // port			:	port number(0, undefined, null means any)
 // cuk			:	container unique key(undefined, null means any)
-// extra		:	extra data(undefined and null means any, string is perfect matching, RegExp object is regular expression)
+// is_strict	:	check for exact mate of parameters such as port/cuk/extra
 //
 // return		:	null(not found) or found hostname(ip) following element array
 //					[
@@ -5693,7 +6075,12 @@ function rawFindRoleHost(dkcobj_permanent, role_key, hostname, ip, port, cuk, ex
 // [NOTE]
 // This function returns all matched hosts and it's information.
 //
-function rawMatchHost(dkcobj_permanent, key_array, target, port, cuk, extra)
+// If the strict flag is true, the port / cuk match is checked.
+// The parameter cuk is checked for openstack or kubernetes.(it convert to extra value)
+// If cuk is based on kubernetes, the value of the strict flag is ignored and strict
+// checking is always performed.
+//
+function rawMatchHost(dkcobj_permanent, key_array, target, port, cuk, is_strict)
 {
 	if(!(dkcobj_permanent instanceof Object) || !dkcobj_permanent.isPermanent()){
 		r3logger.dlog('parameter dkcobj_permanent is not object or not permanent');
@@ -5716,22 +6103,14 @@ function rawMatchHost(dkcobj_permanent, key_array, target, port, cuk, extra)
 		r3logger.elog('port(' + JSON.stringify(port) + ') parameter is wrong.');
 		return false;
 	}
+	port = parseInt(port);
 	if(!apiutil.isSafeString(cuk)){
 		cuk = null;
 	}
-	var	extramatch	= false;
-	var	matchstr	= true;
-	if(!apiutil.isSafeEntity(extra)){
-		extra = null;
-	}else if(apiutil.isSafeString(extra)){
-		// string case
-		extramatch	= true;
-		matchstr	= true;
-	}else if(extra instanceof RegExp){
-		// Regexp
-		extramatch	= true;
-		matchstr	= false;
+	if('boolean' != typeof is_strict){
+		is_strict = false;
 	}
+	var	extra = rawGetExtraFromCuk(cuk);			// make extra from cuk automatically
 
 	//
 	// Keys
@@ -5746,6 +6125,14 @@ function rawMatchHost(dkcobj_permanent, key_array, target, port, cuk, extra)
 			r3logger.wlog('host key array(' + JSON.stringify(key_array[cnt]) + ') in array is not safe string.');
 			continue;
 		}
+		// get host information
+		var	host_value	= dkcobj_permanent.getValue(key_array[cnt], null, true, null);
+		host_value		= apiutil.parseJSON(host_value);
+		if(null == host_value){
+			r3logger.wlog('host key array(' + JSON.stringify(key_array[cnt]) + ') does not have value or it is not JSON value.');
+			continue;
+		}
+
 		// parse hostname(ip) and port by yrn(check hostname and ip yrn paths)
 		var	matches	= key_array[cnt].match(hostptn);
 		if(apiutil.isEmptyArray(matches) || matches.length < 7 || !apiutil.isSafeString(matches[4]) || !apiutil.isSafeString(matches[5])){
@@ -5760,79 +6147,60 @@ function rawMatchHost(dkcobj_permanent, key_array, target, port, cuk, extra)
 		// matches[5] ---> port number
 		// matches[6] ---> container unique key
 		//
-		// compare
-		var	found = false;
-		for(var cnt2 = 0; cnt2 < target.length && !found; ++cnt2){
-			if(target[cnt2] === matches[4]){
-				if(0 === port && null === cuk){													// target port/cuk is any, so this element is matched
-					found = true;
-				}else if(null === cuk){															// target cuk is any
-					if(apiutil.isSafeString(matches[5]) && keys.VALUE_ANY_PORT === matches[5]){	// host port is any, so this element is matched
-						found = true;
-					}else if(String(port) === matches[5]){										// same port(and any cuk)
-						found = true;
-					}
-				}else if(0 === port){															// target port is any
-					if(!apiutil.isSafeString(matches[6])){										// host cuk is any, so this element is matched
-						found = true;
-					}else if(cuk === matches[6]){												// same cuk(and any port)
-						found = true;
-					}
-				}else{																			// target port and cuk is specified
-					if(apiutil.isSafeString(matches[5]) && keys.VALUE_ANY_PORT === matches[5]){	// host port is any
-						if(!apiutil.isSafeString(matches[6])){									// host cuk is any, so this element is matched
-							found = true;
-						}else if(cuk === matches[6]){											// same cuk(and any port)
-							found = true;
-						}
-					}else if(String(port) === matches[5]){										// same port(and any cuk)
-						if(!apiutil.isSafeString(matches[6])){									// host cuk is any, so this element is matched
-							found = true;
-						}else if(cuk === matches[6]){											// same cuk(and any port)
-							found = true;
-						}
-					}
-				}
-			}
-		}
-		if(found){
-			// found target host
-			var	hostobj			= {};
-			var	host_value		= dkcobj_permanent.getValue(key_array[cnt], null, true, null);
+		var	hostobj			= {};
+		hostobj.key			= key_array[cnt];
+		hostobj.port		= (apiutil.isSafeString(matches[5]) && !isNaN(matches[5]))	? parseInt(matches[5])	: 0;
+		hostobj.cuk			= apiutil.isSafeString(matches[6])							? matches[6]			: null;
+		hostobj.extra		= apiutil.isSafeString(host_value.extra)					? host_value.extra		: null;
+		hostobj.hostname	= apiutil.isSafeString(host_value.hostname)					? host_value.hostname	: null;
+		hostobj.ip			= apiutil.isSafeString(host_value.ip)						? host_value.ip			: null;
+		var	host_or_ip		= apiutil.isSafeString(matches[4])							? matches[4]			: null;
 
-			// [NOTE]
-			// When come here during removing target host from role, host_value is empty(null).
-			//
-			if(apiutil.checkSimpleJSON(host_value)){
-				// If need to check extra matching, we check it here.
-				var	is_extra_match = true;
-				if(extramatch){
-					if(matchstr){
-						if(host_value.extra != extra){
-							is_extra_match = false;
-						}
-					}else{
-						var	matches2 = host_value.extra.match(extra);
-						if(apiutil.isEmptyArray(matches2) || matches2.length < 2 || '' === apiutil.getSafeString(matches2[1])){
-							is_extra_match = false;
-						}
-					}
+		// check in target
+		for(var cnt2 = 0; cnt2 < target.length; ++cnt2){
+			if(target[cnt2] !== host_or_ip){
+				continue;
+			}
+			if(is_strict || keys.VALUE_K8S_V1 == hostobj.extra || keys.VALUE_K8S_V1 == extra){
+				// check strictly(if extra is kubernetes, always check strictly)
+				if(port == hostobj.port && cuk == hostobj.cuk && extra == hostobj.extra){
+					found_hosts.push(hostobj);					// add result
+					break;
 				}
-				if(is_extra_match){
-					host_value			= JSON.parse(host_value);
-					hostobj.key			= key_array[cnt];
-					hostobj.hostname	= apiutil.isSafeString(host_value.hostname)							? host_value.hostname	: null;
-					hostobj.ip			= apiutil.isSafeString(host_value.ip)								? host_value.ip			: null;
-					hostobj.port		= apiutil.isSafeEntity(host_value.port) && !isNaN(host_value.port)	? host_value.port		: 0;
-					hostobj.cuk			= apiutil.isSafeString(host_value.cuk)								? host_value.cuk		: null;
-					hostobj.extra		= apiutil.isSafeString(host_value.extra)							? host_value.extra		: null;
-					// add result
-					found_hosts.push(hostobj);
+			}else{
+				// check no strictly
+				if(	(port == hostobj.port	|| rawIsPortAny(port)	|| rawIsPortAny(hostobj.port))	&&
+					(cuk == hostobj.cuk		|| null == cuk			|| null == hostobj.cuk)			&&
+					(extra == hostobj.extra	|| null == extra		|| null == hostobj.extra)		)
+				{
+					found_hosts.push(hostobj);					// add result
+					break;
 				}
 			}
 		}
 	}
 	return (apiutil.isEmptyArray(found_hosts) ? null : found_hosts);
+}
+
+//
+// Small utility for checking port any
+//
+function rawIsPortAny(port)
+{
+	if(!apiutil.isSafeEntity(port)){
+		return false;
+	}
+	var	keys = r3keys();
+	if(apiutil.isSafeString(port) && keys.VALUE_ANY_PORT == port){
+		return true;
+	}
+	if(!isNaN(port)){
+		port = parseInt(port);
+		if(0 === port){
+			return true;
+		}
+	}
+	return false;
 }
 
 //---------------------------------------------------------
@@ -5875,7 +6243,7 @@ function rawCreateResourceEx(dkcobj_permanent, tenant, service, resourcename, ty
 		r3logger.elog('some parameters are wrong : tenant=' + JSON.stringify(tenant) + ', resourcename=' + JSON.stringify(resourcename));
 		return false;
 	}
-	if(apiutil.isSafeStrings(service)){
+	if(apiutil.isSafeString(service)){
 		service			= service.toLowerCase();
 	}else{
 		service			= null;														// clear
@@ -5894,13 +6262,13 @@ function rawCreateResourceEx(dkcobj_permanent, tenant, service, resourcename, ty
 	}
 	if(apiutil.compareCaseString(keys.VALUE_STRING_TYPE, type)){
 		// type is string
-		if(apiutil.isSafeStrings(data)){
+		if(apiutil.isSafeString(data)){
 			is_data			= true;
 		}else if(!apiutil.isSafeEntity(data)){
 			is_data			= false;
 		}else if('' === data){
 			is_data			= true;
-		}else if(!isNaN(data)){														// case for JSON.parser returns not string
+		}else if(!isNaN(data)){														// case for JSON.parse returns not string
 			is_data			= true;
 			data			= String(data);
 		}else{
@@ -5936,7 +6304,7 @@ function rawCreateResourceEx(dkcobj_permanent, tenant, service, resourcename, ty
 		r3logger.elog('parameter resource_keys is wrong : resource_keys=' + JSON.stringify(resource_keys));
 		return false;
 	}
-	if(apiutil.isSafeStrings(service)){
+	if(apiutil.isSafeString(service)){
 		// if the service is specified, alias must be empty.
 		if(apiutil.isSafeEntity(alias_resources)){
 			r3logger.elog('parameter alias_resources is not empty : alias_resources=' + JSON.stringify(alias_resources));
@@ -6046,12 +6414,12 @@ function rawCreateResourceEx(dkcobj_permanent, tenant, service, resourcename, ty
 
 	// aliases
 	value = dkcobj_permanent.getValue(alias_key, null, true, null);
-	value = JSON.parse(value);
+	value = apiutil.parseJSON(value);
 	if(is_alias){
 		var	cnt;
 		var	tmpres;
 		if(0 === alias_resources.length){
-			if(null !== value && undefined !== value){
+			if(null !== value){
 				// if there is alias array, alias resource reference is needed to decrement
 				if(!apiutil.isEmptyArray(value)){
 					for(cnt = 0; cnt < value.length; ++cnt){
@@ -6334,7 +6702,7 @@ function rawCreateResourceByIP(ip, port, cuk, roleyrn, resourcename, type, data,
 	rolename	= rolematches[3];
 
 	// check host
-	var	host_info = rawFindRoleHost(dkcobj, roleyrn, null, ip, port, cuk);
+	var	host_info = rawFindRoleHost(dkcobj, roleyrn, null, ip, port, cuk, false);			// not strictly check
 	if(apiutil.isEmptyArray(host_info)){
 		resobj.result	= false;
 		resobj.message	= 'ip:port(' + ip + ':' + String(port) + ') is not role(' + roleyrn + ') member.';
@@ -6526,7 +6894,7 @@ function rawGetResourcesEx(dkcobj_permanent, resource_key, resdata, is_expand, i
 		r3logger.elog('parameter dkcobj_permanent is not object or not permanent');
 		return false;
 	}
-	if(!apiutil.isSafeStrings(resource_key)){
+	if(!apiutil.isSafeString(resource_key)){
 		r3logger.elog('some parameters are wrong : resource_key=' + JSON.stringify(resource_key));
 		return false;
 	}
@@ -6606,7 +6974,7 @@ function rawGetResourcesEx(dkcobj_permanent, resource_key, resdata, is_expand, i
 	// check resource under aliases
 	value = dkcobj_permanent.getValue(alias_key, null, true, null);
 	if(is_expand){
-		if(apiutil.isSafeEntity(value)){
+		if(apiutil.checkSimpleJSON(value)){
 			value = JSON.parse(value);
 			if(!apiutil.isEmptyArray(value)){
 				for(cnt = 0; cnt < value.length; ++cnt){
@@ -6618,7 +6986,7 @@ function rawGetResourcesEx(dkcobj_permanent, resource_key, resdata, is_expand, i
 			}
 		}
 	}else{
-		if(apiutil.isSafeEntity(value)){
+		if(apiutil.checkSimpleJSON(value)){
 			value = JSON.parse(value);
 		}else{
 			value = [];
@@ -6628,7 +6996,7 @@ function rawGetResourcesEx(dkcobj_permanent, resource_key, resdata, is_expand, i
 
 	// get resource keys
 	value = dkcobj_permanent.getValue(reskeys_key, null, true, null);
-	value = JSON.parse(value);
+	value = apiutil.parseJSON(value);
 	if(apiutil.isSafeEntity(value)){
 		// [NOTE]
 		// key's value is object(keyname-value), and we set these as following two key name into resdata[keys.VALUE_KEYS_TYPE].
@@ -6686,7 +7054,7 @@ function rawGetResourcesEx(dkcobj_permanent, resource_key, resdata, is_expand, i
 		}else{
 			// data type is object, so we merge object as over writing
 			//
-			value = JSON.parse(value);
+			value = apiutil.parseJSON(value);
 			if(apiutil.isSafeEntity(resdata[keys.VALUE_OBJECT_TYPE])){
 				resdata[keys.VALUE_OBJECT_TYPE] = apiutil.mergeObjects(resdata[keys.VALUE_OBJECT_TYPE], value);
 			}else{
@@ -7276,7 +7644,7 @@ function rawGetResourceByIP(ip, port, cuk, roleyrn, resyrn, type, keyname)
 	rolename		= rolematches[3];
 
 	// check host
-	var	host_info = rawFindRoleHost(dkcobj, roleyrn, null, ip, port, cuk);
+	var	host_info = rawFindRoleHost(dkcobj, roleyrn, null, ip, port, cuk, false);			// not strictly check
 	if(apiutil.isEmptyArray(host_info)){
 		resobj.result	= false;
 		resobj.message	= 'ip:port(' + ip + ':' + String(port) + ') is not role(' + roleyrn + ') member.';
@@ -7390,7 +7758,7 @@ function rawRemoveResourceEx(dkcobj_permanent, tenant, service, resource, type, 
 
 		// check alias key and decrement resource reference in alias's list.
 		value = dkcobj_permanent.getValue(alias_key, null, true, null);
-		value = JSON.parse(value);
+		value = apiutil.parseJSON(value);
 		if(!apiutil.isEmptyArray(value)){
 			for(cnt = 0; cnt < value.length; ++cnt){
 				var	tmpres = rawIncDecReferenceCount(dkcobj_permanent, value[cnt], false);
@@ -7504,7 +7872,7 @@ function rawRemoveResourceEx(dkcobj_permanent, tenant, service, resource, type, 
 		if(keys.VALUE_KEYS_TYPE === type){
 			// get keys value
 			value = dkcobj_permanent.getValue(reskeys_key, null, true, null);
-			value = apiutil.isSafeEntity(value) ? JSON.parse(value) : null;
+			value = apiutil.parseJSON(value);
 
 			// remove keynames(or all) from value
 			var	is_keys_updated	= false;
@@ -7535,7 +7903,7 @@ function rawRemoveResourceEx(dkcobj_permanent, tenant, service, resource, type, 
 		if(keys.VALUE_ALIAS_TYPE === type){
 			// get aliases value
 			value = dkcobj_permanent.getValue(alias_key, null, true, null);
-			value = apiutil.isSafeEntity(value) ? JSON.parse(value) : null;
+			value = apiutil.parseJSON(value);
 
 			// remove aliases(or all) from value
 			var	is_aliases_updated	= false;
@@ -7841,7 +8209,7 @@ function rawRemoveResourceByIP(ip, port, cuk, roleyrn, resource, type, keynames)
 	rolename	= rolematches[3];
 
 	// check host
-	var	host_info = rawFindRoleHost(dkcobj, roleyrn, null, ip, port, cuk);
+	var	host_info = rawFindRoleHost(dkcobj, roleyrn, null, ip, port, cuk, false);			// not strictly check
 	if(apiutil.isEmptyArray(host_info)){
 		resobj.result	= false;
 		resobj.message	= 'ip:port(' + ip + ':' + String(port) + ') is not role(' + roleyrn + ') member.';
@@ -8022,7 +8390,7 @@ function rawCheckResources(dkcobj_permanent, resource, is_parent, type, keyname,
 
 	// check resource under aliases
 	value = dkcobj_permanent.getValue(alias_key, null, true, null);
-	value = apiutil.isSafeEntity(value) ? JSON.parse(value) : null;
+	value = apiutil.parseJSON(value);
 	if(!apiutil.isEmptyArray(value)){
 		for(cnt = 0; cnt < value.length; ++cnt){
 			// check alias resource keys(do not check parent for aliases)
@@ -8055,7 +8423,7 @@ function rawCheckResources(dkcobj_permanent, resource, is_parent, type, keyname,
 	// get keys for this resource(type is any or "keys")
 	if(null === type || keys.VALUE_KEYS_TYPE === type){
 		value = dkcobj_permanent.getValue(reskeys_key, null, true, null);
-		value = JSON.parse(value);
+		value = apiutil.parseJSON(value);
 		if(apiutil.isSafeEntity(value)){
 			// has keys data
 			if(keys.VALUE_KEYS_TYPE !== type){
@@ -8320,7 +8688,7 @@ function rawCheckResourceByIP(ip, port, cuk, roleyrn, resource, type, keyname)
 	rolename	= rolematches[3];
 
 	// check host
-	var	host_info = rawFindRoleHost(dkcobj, roleyrn, null, ip, port, cuk);
+	var	host_info = rawFindRoleHost(dkcobj, roleyrn, null, ip, port, cuk, false);			// not strictly check
 	if(apiutil.isEmptyArray(host_info)){
 		resobj.result	= false;
 		resobj.message	= 'ip:port(' + ip + ':' + String(port) + ') is not role(' + roleyrn + ') member.';
@@ -8370,7 +8738,7 @@ function rawCreatePolicyEx(dkcobj_permanent, user, tenant, service, policy, effe
 		r3logger.elog('parameter dkcobj_permanent is not object or not permanent');
 		return false;
 	}
-	if(!apiutil.isSafeStrings(tenant)){														// allow other argument is empty
+	if(!apiutil.isSafeString(tenant)){														// allow other argument is empty
 		r3logger.elog('some parameters are wrong : tenant=' + JSON.stringify(tenant));
 		return false;
 	}
@@ -8462,7 +8830,7 @@ function rawCreatePolicyEx(dkcobj_permanent, user, tenant, service, policy, effe
 		}
 		if(action instanceof Array){
 			is_action	= true;
-		}else if(apiutil.isSafeStrings(action)){
+		}else if(apiutil.isSafeString(action)){
 			action		= [action];
 			is_action	= true;
 		}else if(!apiutil.isSafeEntity(action)){
@@ -8477,7 +8845,7 @@ function rawCreatePolicyEx(dkcobj_permanent, user, tenant, service, policy, effe
 		}
 		if(condition instanceof Array){
 			is_condition= true;
-		}else if(apiutil.isSafeStrings(condition)){
+		}else if(apiutil.isSafeString(condition)){
 			condition	= [condition];
 			is_condition= true;
 		}else if(!apiutil.isSafeEntity(condition)){
@@ -8506,7 +8874,7 @@ function rawCreatePolicyEx(dkcobj_permanent, user, tenant, service, policy, effe
 	// check resource parameter(common check for both case)
 	if(resource instanceof Array){
 		is_resource	= true;
-	}else if(apiutil.isSafeStrings(resource)){
+	}else if(apiutil.isSafeString(resource)){
 		resource	= [resource];
 		is_resource = true;
 	}else if(!apiutil.isSafeEntity(resource)){
@@ -8584,7 +8952,7 @@ function rawCreatePolicyEx(dkcobj_permanent, user, tenant, service, policy, effe
 
 	// action key
 	value = dkcobj_permanent.getValue(action_key, null, true, null);
-	value = JSON.parse(value);
+	value = apiutil.parseJSON(value);
 	if((is_action && !apiutil.compareArray(value, action)) || (!is_action && (null === value || undefined === value))){
 		if(!dkcobj_permanent.setValue(action_key, JSON.stringify(action))){					// update value action -> yrn:yahoo:<service>::<tenant>:policy:<policy>/action
 			r3logger.elog('could not set ' + JSON.stringify(action) + ' value to ' + action_key + ' key');
@@ -8594,7 +8962,7 @@ function rawCreatePolicyEx(dkcobj_permanent, user, tenant, service, policy, effe
 
 	// resource key
 	value = dkcobj_permanent.getValue(resource_key, null, true, null);
-	value = JSON.parse(value);
+	value = apiutil.parseJSON(value);
 	if((is_resource && !apiutil.compareArray(value, resource)) || (!is_resource && (null === value || undefined === value))){
 		// get removing element(resource) & decrement it's reference
 		delarr = apiutil.getDeletingDifferenceArray(value, resource);
@@ -8621,7 +8989,7 @@ function rawCreatePolicyEx(dkcobj_permanent, user, tenant, service, policy, effe
 
 	// condition key
 	value = dkcobj_permanent.getValue(condition_key, null, true, null);
-	value = JSON.parse(value);
+	value = apiutil.parseJSON(value);
 	if((is_condition && !apiutil.compareArray(value, condition)) || (!is_condition && (null === value || undefined === value))){
 		if(!dkcobj_permanent.setValue(condition_key, JSON.stringify(condition))){			// update value condition -> yrn:yahoo:<service>::<tenant>:policy:<policy>/condition
 			r3logger.elog('could not set ' + JSON.stringify(condition) + ' value to ' + condition_key + ' key');
@@ -8639,7 +9007,7 @@ function rawCreatePolicyEx(dkcobj_permanent, user, tenant, service, policy, effe
 
 	// alias
 	value = dkcobj_permanent.getValue(alias_key, null, true, null);
-	value = JSON.parse(value);
+	value = apiutil.parseJSON(value);
 	if(is_alias){
 		if(0 === alias_policy.length){
 			if(null !== value && undefined !== value){
@@ -8822,7 +9190,7 @@ function rawRemovePolicyEx(dkcobj_permanent, tenant, service, policy)
 
 	// decrement alias policy's reference
 	value = dkcobj_permanent.getValue(alias_key, null, true, null);
-	value = JSON.parse(value);
+	value = apiutil.parseJSON(value);
 	if(!apiutil.isEmptyArray(value)){
 		for(cnt = 0; cnt < value.length; ++cnt){
 			tmpres = rawIncDecReferenceCount(dkcobj_permanent, value[cnt], false);
@@ -8834,7 +9202,7 @@ function rawRemovePolicyEx(dkcobj_permanent, tenant, service, policy)
 
 	// decrement resource's reference
 	value = dkcobj_permanent.getValue(resource_key, null, true, null);
-	value = JSON.parse(value);
+	value = apiutil.parseJSON(value);
 	if(!apiutil.isEmptyArray(value)){
 		for(cnt = 0; cnt < value.length; ++cnt){
 			tmpres = rawIncDecReferenceCount(dkcobj_permanent, value[cnt], false);
@@ -9049,7 +9417,7 @@ function rawGetPolicyAll(user, tenant, service, policy)
 	policy_data.action = new Array(0);
 	if(apiutil.findStringInArray(subkeylist, action_key)){
 		value = dkcobj.getValue(action_key, null, true, null);
-		value = JSON.parse(value);
+		value = apiutil.parseJSON(value);
 		if(!apiutil.isSafeEntity(value)){
 			r3logger.wlog('policy(' + policy_key + ') have wrong action value(' + JSON.stringify(value) + '), then returns default value(read).');
 			policy_data.action.push(keys.VALUE_READ);
@@ -9089,7 +9457,7 @@ function rawGetPolicyAll(user, tenant, service, policy)
 	policy_data.resource = new Array(0);
 	if(apiutil.findStringInArray(subkeylist, resource_key)){
 		value = dkcobj.getValue(resource_key, null, true, null);
-		value = JSON.parse(value);
+		value = apiutil.parseJSON(value);
 		if(!apiutil.isSafeEntity(value)){
 			r3logger.wlog('policy(' + policy_key + ') have wrong resource value(' + JSON.stringify(value) + '), then returns default empty array.');
 
@@ -9118,7 +9486,7 @@ function rawGetPolicyAll(user, tenant, service, policy)
 	policy_data.condition = new Array(0);
 	if(apiutil.findStringInArray(subkeylist, condition_key)){
 		value = dkcobj.getValue(condition_key, null, true, null);
-		value = JSON.parse(value);
+		value = apiutil.parseJSON(value);
 		if(!apiutil.isSafeEntity(value)){
 			r3logger.wlog('policy(' + policy_key + ') have wrong condition value(' + JSON.stringify(value) + '), then returns default empty array.');
 
@@ -9162,7 +9530,7 @@ function rawGetPolicyAll(user, tenant, service, policy)
 	policy_data.alias = new Array(0);
 	if(apiutil.findStringInArray(subkeylist, alias_key)){
 		value = dkcobj.getValue(alias_key, null, true, null);
-		value = JSON.parse(value);
+		value = apiutil.parseJSON(value);
 		if(!apiutil.isSafeEntity(value)){
 			r3logger.wlog('policy(' + policy_key + ') have wrong alias value(' + JSON.stringify(value) + '), then returns default empty array.');
 
@@ -9247,7 +9615,7 @@ function rawCheckPolicies(dkcobj_permanent, policy, resource, action, summary_re
 
 	// check result of policy under aliases
 	var	value	= dkcobj_permanent.getValue(alias_key, null, true, null);
-	value		= apiutil.isSafeEntity(value) ? JSON.parse(value) : null;
+	value		= apiutil.parseJSON(value);
 	if(!apiutil.isEmptyArray(value)){
 		for(cnt = 0; cnt < value.length; ++cnt){
 			// check alias policy keys
@@ -9264,11 +9632,11 @@ function rawCheckPolicies(dkcobj_permanent, policy, resource, action, summary_re
 	// check own resource
 	var	is_matched	= false;
 	value			= dkcobj_permanent.getValue(resource_key, null, true, null);
-	value			= apiutil.isSafeEntity(value) ? JSON.parse(value) : null;
+	value			= apiutil.parseJSON(value);
 	if(apiutil.findStringInArray(value, resource)){
 		// resource is target for this policy
 		value = dkcobj_permanent.getValue(action_key, null, true, null);
-		value = apiutil.isSafeEntity(value) ? JSON.parse(value) : null;
+		value = apiutil.parseJSON(value);
 		// check action
 		if(!apiutil.isEmptyArray(value)){
 			// check this policy's action
@@ -10427,19 +10795,34 @@ exports.addHost = function(tenant, role, hostname, ip, port, cuk, extra)
 	return rawAddHost(tenant, role, null, hostname, ip, port, cuk, extra);
 };
 
-exports.removeHost = function(tenant, role, hostname, ip, port, cuk)
+exports.removeHost = function(tenant, role, target, tg_port, tg_cuk, req_ip, req_port, req_cuk)
 {
 	// [NOTE]
 	// Now do not set hosts to role under service, then we do not need to remove
 	// hosts under service + tenant.
 	// But if need to remove hosts to it, you can set role as full yrn role path.
 	//
-	return rawRemoveHost(tenant, null, role, hostname, ip, port, cuk);
+	return rawRemoveHost(tenant, null, role, target, tg_port, tg_cuk, req_ip, req_port, req_cuk);
 };
 
-exports.removeIpsByCuk = function(cuk, extra, host, remove_under_role)
+exports.removeIpsByCuk = function(cuk, host, remove_under_role)
 {
-	return rawRemoveIpsByCuk(cuk, extra, host, remove_under_role);
+	return rawRemoveIpsByCuk(cuk, host, remove_under_role);
+};
+
+exports.isKubernetesCuk = function(cuk)
+{
+	return rawIsKubernetesCuk(cuk);
+};
+
+exports.compareIpAndKubernetesCuk = function(ip, cuk)
+{
+	return rawCompareIpAndKubernetesCuk(ip, cuk);
+};
+
+exports.getExtraFromCuk = function(cuk)
+{
+	return rawGetExtraFromCuk(cuk);
 };
 
 //
@@ -10448,9 +10831,16 @@ exports.removeIpsByCuk = function(cuk, extra, host, remove_under_role)
 // are required for it.
 // It is recommended to start the process of enumerating IP addresses as a separate process.
 //
-exports.getAllIpDatasByCuk = function()
+exports.getAllIpDatasByCuk = function(is_openstack)
 {
-	return rawGetAllIpDatasByCuk();
+	var	extra;
+	var	keys	= r3keys();
+	if('boolean' !== typeof is_openstack || is_openstack){
+		extra = keys.VALUE_OPENSTACK_V1;		// default
+	}else{
+		extra = keys.VALUE_K8S_V1;
+	}
+	return rawGetAllIpDatasByCuk(extra);
 };
 
 //
@@ -10464,24 +10854,24 @@ exports.removeIpAddressWithCuk = function(ipdatas, pendingsec, logger)
 	return rawRemoveIpAddressWithCuk(ipdatas, pendingsec, logger);
 };
 
-exports.findHost = function(tenant, role, hostname, ip, port, cuk, extra)
+exports.findHost = function(tenant, role, hostname, ip, port, cuk, is_strict)
 {
 	// [NOTE]
 	// Now do not set hosts to role under service, then we do not need to remove
 	// hosts under service + tenant.
 	// But if need to remove hosts to it, you can set role as full yrn role path.
 	//
-	return rawFindHost(tenant, null, role, hostname, ip, port, cuk, extra);
+	return rawFindHost(tenant, null, role, hostname, ip, port, cuk, is_strict);
 };
 
-exports.findRoleHost = function(dkcobj_permanent, role_key, hostname, ip, port, cuk, extra)
+exports.findRoleHost = function(dkcobj_permanent, role_key, hostname, ip, port, cuk)
 {
 	var	dkcobj = null;
 	if(!(dkcobj_permanent instanceof Object)){
 		dkcobj			= k2hdkc(dkcconf, dkcport, true, false);				// use permanent object(need to clean)
 		dkcobj_permanent= dkcobj;
 	}
-	var	result = rawFindRoleHost(dkcobj_permanent, role_key, hostname, ip, port, cuk, extra);
+	var	result = rawFindRoleHost(dkcobj_permanent, role_key, hostname, ip, port, cuk, false);	// not strictly check
 	if(null != dkcobj){
 		dkcobj.clean();
 	}

--- a/lib/k2hr3keys.js
+++ b/lib/k2hr3keys.js
@@ -74,6 +74,7 @@ exports.getK2hr3Keys = function(user, tenant, service)
 		'VALUE_KEYSTONE_NOPASS':		'kstype_nopasswd',
 		'VALUE_KEYSTONE_SUB':			'kstype_substitute',
 		'VALUE_OPENSTACK_V1':			'openstack-auto-v1',												// used/set from k2hr3-init.sh
+		'VALUE_K8S_V1':					'k8s-auto-v1',														// used/set from k2hr3-kube-init.sh
 
 		// common keywords( part of keyname )
 		'POLICIES_KW':					'policies',
@@ -95,6 +96,7 @@ exports.getK2hr3Keys = function(user, tenant, service)
 		'STATUS_KW':					'status',
 		'DATE_KW':						'date',
 		'SEED_KW':						'seed',
+		'ROLE_TOKEN_KW':				'tokens',
 
 		// ACR keywords
 		'ACR_POLICY_KW':				'acr-policy',
@@ -104,6 +106,17 @@ exports.getK2hr3Keys = function(user, tenant, service)
 		'ACR_RESOURCE_TYPE_KEY':		'type',
 		'ACR_RESOURCE_DATA_KEY':		'data',
 		'ACR_RESOURCE_KEYS_KEY':		'keys',
+
+		// kubernetes cuk keywords
+		'K8S_NAMESPACE_INCUK_KEY':		'k8s_namespace',
+		'K8S_SA_INCUK_KEY':				'k8s_service_account',
+		'K8S_NODENAME_INCUK_KEY':		'k8s_node_name',
+		'K8S_NODEIP_INCUK_KEY':			'k8s_node_ip',
+		'K8S_PODNAME_INCUK_KEY':		'k8s_pod_name',
+		'K8S_PODID_INCUK_KEY':			'k8s_pod_id',
+		'K8S_PODIP_INCUK_KEY':			'k8s_pod_ip',
+		'K8S_CONTAINERID_INCUK_KEY':	'k8s_container_id',
+		'K8S_RAND_INCUK_KEY':			'k8s_k2hr3_rand',
 
 		// common key names
 		'YRN_KEY':						'yrn',
@@ -121,6 +134,7 @@ exports.getK2hr3Keys = function(user, tenant, service)
 		'KEYSTONE_TOP_KEY':				'yrn:yahoo::::keystone',
 		'IAAS_TOP_KEY':					'yrn:yahoo::::iaas',
 		'IAAS_OS_TOP_KEY':				'yrn:yahoo::::iaas:openstack',
+		'IAAS_K8S_TOP_KEY':				'yrn:yahoo::::iaas:k8s',
 		'MASTER_SERVICE_TOP_KEY':		'yrn:yahoo::::service',
 		'ANYTENANT_SERVICE_TOP_KEY':	'yrn:yahoo::::service:',
 		'ANYTENANT_SERVICE_KEY':		'yrn:yahoo::::service::anytenant',
@@ -129,6 +143,7 @@ exports.getK2hr3Keys = function(user, tenant, service)
 		'MATCH_ANY_SERVICE_MASTER':		'yrn:yahoo::::service:(.*)',
 		'MATCH_ANY_IAAS':				'yrn:yahoo::::iaas:(.*)',
 		'MATCH_ANY_IAAS_OS':			'yrn:yahoo::::iaas:openstack:(.*)',
+		'MATCH_ANY_IAAS_K8S':			'yrn:yahoo::::iaas:k8s:(.*)',
 		'MATCH_ANY_SERVICE_TENANT':		'yrn:yahoo:(.*)::(.*):(.*)',
 		'MATCH_ANY_TENANT_MAIN':		'yrn:yahoo:(.*)::(.*)',
 		'MATCH_ANY_TENANT_ROLE':		'yrn:yahoo:(.*)::(.*):role:(.*)',
@@ -142,7 +157,11 @@ exports.getK2hr3Keys = function(user, tenant, service)
 		'MATCH_ANY_IP_PORT':			'yrn:yahoo:(.*)::(.*):role:(.*)/hosts/ip/(.*) (.*) (.*)',
 		'MATCH_ANY_IP_KEYS':			'yrn:yahoo:(.*)::(.*):role:(.*)/hosts/ip',
 		'MATCH_ANY_KS_REGION':			'yrn:yahoo::::keystone:(.*)',
-		'MATCH_ANY_USER_TOKEN':			'yrn:yahoo::::user:(.*):tenant/(.*)/token/(.*)'
+		'MATCH_ANY_USER_TOKEN':			'yrn:yahoo::::user:(.*):tenant/(.*)/token/(.*)',
+		'MATCH_ANY_ROLE_TOKEN':			'yrn:yahoo::::token:role/(.*)',
+		'MATCH_URI_GET_ROLE_DATA':		'^/v1/role/(.*)',
+		'MATCH_URI_GET_RTOKEN':			'^/v1/role/token/(.*)',
+		'MATCH_URI_GET_RTOKEN_LIST':	'^/v1/role/token/list/(.*)'
 	};
 
 	var	_user	= apiutil.getSafeString(user).toLowerCase();
@@ -151,14 +170,14 @@ exports.getK2hr3Keys = function(user, tenant, service)
 
 	keywords.SERVICE_TOP_KEY						= keywords.NO_SERVICE_KEY			+ _service;			// "yrn:yahoo:<service>"
 	keywords.SERVICE_NO_REGION_KEY					= keywords.SERVICE_TOP_KEY			+ ':';				// "yrn:yahoo:<service>:"
-	if(apiutil.isSafeStrings(_service)){
+	if(apiutil.isSafeString(_service)){
 		keywords.MASTER_SERVICE_KEY					= keywords.MASTER_SERVICE_TOP_KEY	+ ':' + _service;	// "yrn:yahoo::::service:<service>"
 		keywords.SERVICE_OWNER_KEY					= keywords.MASTER_SERVICE_KEY		+ ':owner';			// "yrn:yahoo::::service:<service>:owner"
 		keywords.SERVICE_TENANT_KEY					= keywords.MASTER_SERVICE_KEY		+ ':tenant';		// "yrn:yahoo::::service:<service>:tenant"
 		keywords.SERVICE_VERIFY_TENANT_KEY			= keywords.MASTER_SERVICE_KEY		+ ':verify';		// "yrn:yahoo::::service:<service>:verify"
 	}
 
-	if(apiutil.isSafeStrings(_tenant)){
+	if(apiutil.isSafeString(_tenant)){
 		// tenant key with service(allowed null)
 		keywords.TENANT_TOP_KEY						= keywords.SERVICE_NO_REGION_KEY	+ ':' + _tenant;	// "yrn:yahoo:<service>::<tenant>"
 
@@ -178,14 +197,14 @@ exports.getK2hr3Keys = function(user, tenant, service)
 		keywords.RESOURCE_TOP_KEY					= keywords.TENANT_TOP_KEY			+ ':' + 'resource';	// "yrn:yahoo:<service>::<tenant>:resource"
 	}
 
-	if(apiutil.isSafeStrings(_user)){
+	if(apiutil.isSafeString(_user)){
 		keywords.USER_KEY							= keywords.USER_TOP_KEY				+ ':' + _user;		// "yrn:yahoo::::user:<user>"
 		keywords.USER_ID_KEY						= keywords.USER_KEY					+ ':id';			// "yrn:yahoo::::user:<user>:id"
 		keywords.USER_TENANT_TOP_KEY				= keywords.USER_KEY					+ ':tenant';		// "yrn:yahoo::::user:<user>:tenant"
 		keywords.USER_TENANT_COMMON_KEY				= keywords.USER_TENANT_TOP_KEY		+ '/';				// "yrn:yahoo::::user:<user>:tenant/"
 		keywords.USER_TENANT_UNSCOPE_TOKEN_KEY		= keywords.USER_TENANT_COMMON_KEY	+ '/token';			// "yrn:yahoo::::user:<user>:tenant//token"
 
-		if(apiutil.isSafeStrings(tenant)){
+		if(apiutil.isSafeString(tenant)){
 			keywords.USER_TENANT_KEY				= keywords.USER_TENANT_COMMON_KEY	+ _tenant;			// "yrn:yahoo::::user:<user>:tenant/<tenant>"
 			keywords.USER_TENANT_SCOPE_TOKEN_KEY	= keywords.USER_TENANT_KEY			+ '/token';			// "yrn:yahoo::::user:<user>:tenant/<tenant>/token"
 			// ambiguous key whether tenant exists or not

--- a/lib/k2hr3tokens.js
+++ b/lib/k2hr3tokens.js
@@ -28,20 +28,28 @@ var	apiutil		= require('./k2hr3apiutil');
 var r3logger	= require('../lib/dbglogging');
 
 //---------------------------------------------------------
-// Keystone api wrapper
+// Configuration
+//	* Keystone api wrapper
+//	* Get expiration for role tokens
 //---------------------------------------------------------
 // [NOTE]
 // We use config which has keystone.type value.
 // Default value is "keystone_v3".
 //
-var	osapi = null;
+var	osapi				= null;
+var	expire_rtoken		= 0;
+var	expire_reg_rtoken	= 0;
 
 (function()
 {
 	var	r3Conf			= require('./k2hr3config').r3ApiConfig;
 	var	apiConf			= new r3Conf();
+
 	var	keystone_type	= './' + apiConf.getKeystoneType();
-	osapi = require(keystone_type);
+	osapi				= require(keystone_type);
+
+	expire_rtoken		= apiConf.getExpireTimeRoleToken();
+	expire_reg_rtoken	= apiConf.getExpireTimeRegRoleToken();
 }());
 
 //---------------------------------------------------------
@@ -420,7 +428,7 @@ function rawGetUserUnscopedTokenWrap(user, passwd, callback)
 //
 function rawGetExistUserToken(user, tenant)
 {
-	if(!apiutil.isSafeStrings(user)){														// allow tenant is null
+	if(!apiutil.isSafeString(user)){														// allow tenant is null
 		r3logger.elog('some parameters are wrong : user=' + JSON.stringify(user) + ', tenant=' + JSON.stringify(tenant));
 		return null;
 	}
@@ -448,14 +456,36 @@ function rawGetExistUserToken(user, tenant)
 	var	resobj = null;
 	for(var cnt = 0; cnt < subkeylist.length; ++cnt){
 		var	token = subkeylist[cnt].replace(keyptn, '');									// get only token string
-		if(!apiutil.isSafeStrings(token)){
+		if(!apiutil.isSafeString(token)){
 			// why?
 			continue;
 		}
+		var	needRemove	= false;
 
-		var	region = dkcobj.getValue(subkeylist[cnt], null, true, null);					// get token region
-		if(!apiutil.isSafeStrings(region)){
-			// token region is not existed, probably it is expired.
+		// check region
+		var	region		= dkcobj.getValue(subkeylist[cnt], null, true, null);				// get token region
+		if(!apiutil.isSafeString(region)){
+			needRemove	= true;
+		}
+
+		// check publisher
+		if(!needRemove){
+			// check publisher
+			var	seed_key	= subkeylist[cnt] + '/' + keys.SEED_KW;							// "yrn:yahoo::::user:<user>:tenant/{<tenant>}/token/<token>/seed"
+			var	token_seed	= dkcobj.getValue(seed_key, null, true, null);					// get token seed
+			if(!apiutil.isSafeString(token_seed)){
+				needRemove	= true;
+			}else{
+				var	publisher = osapi.verifyUserTokenPublisher(token_seed);
+				if(!publisher.result){
+					needRemove	= true;
+				}
+			}
+		}
+
+		// check result
+		if(needRemove){
+			// token region/publisher is not safe, probably it is expired or another publisher type.
 			// then check and remove key under token.
 			//
 			var	token_key = keys.TOKEN_USER_TOP_KEY + '/' + token;
@@ -464,11 +494,10 @@ function rawGetExistUserToken(user, tenant)
 			}
 			// register removing keys
 			rmkeys.push(subkeylist[cnt]);
-
 		}else{
-			// found token
+			// found safe token
 			var	userid = dkcobj.getValue(keys.USER_ID_KEY, null, true, null);				// get user id from "yrn:yahoo::::user:<user name>:id"
-			if(!apiutil.isSafeStrings(userid)){
+			if(!apiutil.isSafeString(userid)){
 				r3logger.wlog('user(' + user + ') id is empty, but continue...');
 			}
 			resobj			= {};
@@ -615,7 +644,9 @@ function rawRemoveScopedUserToken(token)
 //						user:		user name
 //						hostname:	always null
 //						ip:			always null
-//						port:		port number(if host is existed), 0 means any
+//						port:		always 0
+//						cuk:		always null
+//						extra:		always null
 //						tenant:		tenant name
 //						scoped:		role token is always scoped(true)
 //						region:		when user token, the creator region name of the token
@@ -644,6 +675,8 @@ function rawCheckUserToken(token)
 	token_info.ip		= null;
 	token_info.hostname	= null;
 	token_info.port		= 0;
+	token_info.cuk		= null;
+	token_info.extra	= null;
 
 	return token_info;
 }
@@ -666,7 +699,9 @@ function rawCheckUserToken(token)
 //							user:		"user name", if creator is user, this value is user name.(if not, this is null)
 //							ip:			"ip address", if creator is host, this value is ip address.(if not, this is null)
 //							hostname:	"hostname", if creator is host, this value is hostname.(if not, this is null)
-//							port:		port number, if creator is host, this value is port number.(if not, this is 0)
+//							port:		"port number", if creator is host, this value is port number.(if not, this is 0)
+//							cuk:		"cuk", if creator is host on iaas, this value is cuk.(allowed null)
+//							extra:		"extra", if creator is host on iaas, this value is extra.(allowed null)
 //							tenant:		"tenant name" for this role token(this mean token is scoped)
 //							verify:		"random 64bit id for verify token"
 //						}
@@ -682,9 +717,8 @@ function rawCheckUserToken(token)
 // 
 // user			:	this value is parsed from user token
 // tenant		:	this value is parsed from user token
-// base_id		:	this value is array which is lower 64 bit data from user token(used by convertHexStringToBin64() for parsing)
 // role			:	target role name(full yrn or only role name)
-// expire_limit	:	specify expire second(default 24H = 24 * 60 * 60 sec)
+// expire_limit	:	specify expire second(default 24H = 24 * 60 * 60 sec, 0 means no expire time.)
 // 
 // result		:	{
 //						result:		true/false
@@ -703,12 +737,13 @@ function rawCheckUserToken(token)
 //						hostname:	always null
 //						ip:			always null
 //						port:		if creator is host, this value is port number.(if not, this is 0)
+//						cuk:		if creator is host on iaas, this value is cuk.(allowed null)
+//						extra:		if creator is host on iaas, this value is extra.(allowed null)
 //						tenant:		tenant name for this role token(this mean token is scoped)
-//						base:		base id value(this value is only used by check)
-//						verify:		for verify check value
+//						base:		32bytes hex string
 //					}
 // 
-function rawGetRoleTokenByUser(user, tenant, base_id, role, expire_limit)
+function rawGetRoleTokenByUser(user, tenant, role, expire_limit)
 {
 	var	resobj = {result: true, message: null};
 
@@ -718,14 +753,17 @@ function rawGetRoleTokenByUser(user, tenant, base_id, role, expire_limit)
 		r3logger.elog(resobj.message);
 		return resobj;
 	}
-	if(apiutil.isEmptyArray(base_id) || 4 !== base_id.length){								// base_id must be array(4)
-		resobj.result	= false;
-		resobj.message	= 'base_id parameters are wrong : base_id=' + JSON.stringify(base_id);
-		r3logger.elog(resobj.message);
-		return resobj;
-	}
 	if(!apiutil.isSafeEntity(expire_limit) || isNaN(expire_limit)){							// expire_limit must be number or null(undefined)
-		expire_limit = 24 * 60 * 60;														// default 24H
+		expire_limit = expire_rtoken;														// default 24H
+	}else{
+		if(0 == expire_limit){
+			// [NOTE]
+			// If 0, set the maximum value to 10 years.
+			// Disable expire by setting a period of time within which this
+			// application is guaranteed not to survive, as permitted by ISO8601.
+			//
+			expire_limit = expire_reg_rtoken;
+		}
 	}
 
 	// check role name is only name or full yrn path
@@ -769,16 +807,40 @@ function rawGetRoleTokenByUser(user, tenant, base_id, role, expire_limit)
 	//
 	var	role_key		= keys.ROLE_TOP_KEY + ':' + role;									// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}"
 	var	role_id_key		= role_key + '/' + keys.ID_KW;										// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/id"
+	var	role_tokens_key	= role_key + '/' + keys.ROLE_TOKEN_KW;								// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/tokens"
 
-	// role id
-	var	role_id	= dkcobj.getValue(role_id_key, null, true, null);
-	role_id		= JSON.parse(role_id);
-	if(apiutil.isEmptyArray(role_id) || role_id.length < 4){
+	// user id
+	var	user_id = dkcobj.getValue(keys.USER_ID_KEY, null, true, null);						// get user id from "yrn:yahoo::::user:<user name>:id"
+	if(!apiutil.isSafeString(user_id)){
 		resobj.result	= false;
-		resobj.message	= 'could not get role id(' + role_id_key + ') value, or it is wrong value(' + JSON.stringify(role_id) + ').';
+		resobj.message	= 'could not get user id(' + keys.USER_ID_KEY + ') value, or it is wrong value(' + JSON.stringify(user_id) + ').';
 		r3logger.elog(resobj.message);
 		dkcobj.clean();
 		return resobj;
+	}
+
+	// role id
+	var	role_id	= dkcobj.getValue(role_id_key, null, true, null);
+	if(!apiutil.isSafeStrUuid4(role_id)){
+		var	isError		= false;
+		var	old_role_id	= apiutil.parseJSON(role_id);
+		if(!apiutil.isEmptyArray(old_role_id) && 4 == old_role_id.length){
+			// old version id, so reset new valus(UUID4) here.
+			role_id = apiutil.getStrUuid4();
+			if(!dkcobj.setValue(role_id_key, role_id)){										// set value -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/id
+				isError			= true;
+				resobj.message	= 'could not get role id(' + role_id_key + ') value, because failed to reset new role id instead of old id.';
+			}
+		}else{
+			isError			= true;
+			resobj.message	= 'could not get role id(' + role_id_key + ') value, or it is wrong value(' + JSON.stringify(role_id) + ').';
+		}
+		if(isError){
+			resobj.result	= false;
+			r3logger.elog(resobj.message);
+			dkcobj.clean();
+			return resobj;
+		}
 	}
 
 	// make token value
@@ -792,8 +854,9 @@ function rawGetRoleTokenByUser(user, tenant, base_id, role, expire_limit)
 	token_value.hostname= null;																// hostname(creator)
 	token_value.ip		= null;																// ip(creator)
 	token_value.port	= 0;																// port(creator)
+	token_value.cuk		= null;																// cuk(creator)
+	token_value.extra	= null;																// extra(creator)
 	token_value.tenant	= tenant;															// tenant(scope)
-	token_value.base	= base_id;															// base id
 
 	// role token and yrn key
 	var	role_token		= '';
@@ -801,14 +864,17 @@ function rawGetRoleTokenByUser(user, tenant, base_id, role, expire_limit)
 
 	// create key
 	for(var is_loop = true; is_loop; ){														// for eslint
-		// set verify value
-		token_value.verify	= apiutil.getRandomBin64();										// random value
-
 		// make role token
-		var	hiBinToken		= apiutil.makeXorValue(token_value.base, token_value.verify);
-		var	lowBinToken		= apiutil.makeXorValue(role_id, token_value.verify);
-		role_token			= apiutil.convertBin64ToHexString(hiBinToken);
-		role_token			+= apiutil.convertBin64ToHexString(lowBinToken);
+		var	token_elements	= apiutil.makeStringToken256(user_id, role_id);
+		if(!apiutil.isSafeEntity(token_elements)){
+			resobj.result	= false;
+			resobj.message	= 'could not make token from ' + JSON.stringify(user_id) + ' and ' + JSON.stringify(role_id);
+			r3logger.elog(resobj.message);
+			dkcobj.clean();
+			return resobj;
+		}
+		role_token			= token_elements.str_token;
+		token_value.base	= token_elements.str_base;										// token base
 
 		// role token key
 		token_role_key		= keys.TOKEN_ROLE_TOP_KEY + '/' + role_token;					// "yrn:yahoo::::token:role/<role token>"
@@ -836,6 +902,18 @@ function rawGetRoleTokenByUser(user, tenant, base_id, role, expire_limit)
 		if(!dkcobj.setSubkeys(keys.TOKEN_ROLE_TOP_KEY, subkeylist)){						// add subkey yrn:yahoo::::token:role/<role token> -> yrn:yahoo::::token:role
 			resobj.result	= false;
 			resobj.message	= 'could not add ' + token_role_key + ' subkey under ' + keys.TOKEN_ROLE_TOP_KEY + ' key';
+			r3logger.elog(resobj.message);
+			dkcobj.clean();
+			return resobj;
+		}
+	}
+
+	// Add token to role tokens key's subkey list
+	subkeylist	= apiutil.getSafeArray(dkcobj.getSubkeys(role_tokens_key, true));
+	if(apiutil.tryAddStringToArray(subkeylist, token_role_key)){
+		if(!dkcobj.setSubkeys(role_tokens_key, subkeylist)){								// add subkey yrn:yahoo::::token:role/<role token> -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/tokens
+			resobj.result	= false;
+			resobj.message	= 'could not add ' + token_role_key + ' subkey under ' + role_tokens_key + ' key';
 			r3logger.elog(resobj.message);
 			dkcobj.clean();
 			return resobj;
@@ -876,9 +954,10 @@ function rawGetRoleTokenByUser(user, tenant, base_id, role, expire_limit)
 //						hostname:	always null
 //						ip:			if creator is host, this value is ip address.
 //						port:		if creator is host, this value is port number.(if not, this is 0)
+//						cuk:		if creator is host on iaas, this value is cuk.(allowed null)
+//						extra:		if creator is host on iaas, this value is extra.(allowed null)
 //						tenant:		tenant name for this role token(this mean token is scoped)
-//						base:		base id value(this value is only used by check)
-//						verify:		for verify check value
+//						base:		32bytes hex string
 //					}
 // 
 // The role token which is built by host is made by only IP address.
@@ -904,8 +983,11 @@ function rawGetRoleTokenByIP(ip, port, cuk, tenant, role, expire_limit)
 	if(!apiutil.isSafeEntity(port) || isNaN(port)){											// port must be number or null(undefined)
 		port = 0;																			// force set port 0(any).
 	}
+	if(!apiutil.isSafeString(cuk)){															// cuk is string if spacified
+		cuk = null;																			// force set null.
+	}
 	if(!apiutil.isSafeEntity(expire_limit) || isNaN(expire_limit)){							// expire_limit must be number or null(undefined)
-		expire_limit = 24 * 60 * 60;														// default 24H
+		expire_limit = expire_rtoken;														// default 24H
 	}
 
 	// check role name is only name or full yrn path
@@ -949,34 +1031,36 @@ function rawGetRoleTokenByIP(ip, port, cuk, tenant, role, expire_limit)
 	//
 	var	role_key		= keys.ROLE_TOP_KEY + ':' + role;									// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}"
 	var	role_id_key		= role_key + '/' + keys.ID_KW;										// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/id"
+	var	role_tokens_key	= role_key + '/' + keys.ROLE_TOKEN_KW;								// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/tokens"
 
 	// find host key and get host id for base id
 	var	host_info		= k2hr3.findRoleHost(dkcobj, role_key, null, ip, port, cuk);
 	if(apiutil.isEmptyArray(host_info)){
 		resobj.result	= false;
-		resobj.message	= 'Not found ip(' + ip + ') with port(' + String(port) + ') in tenant(' + tenant + ') + role(' + role + ')';
+		resobj.message	= 'Not found ip(' + ip + ') with port(' + String(port) + ') and cuk(' + JSON.stringify(cuk) + ') in tenant(' + tenant + ') + role(' + role + ')';
 		r3logger.elog(resobj.message);
 		dkcobj.clean();
 		return resobj;
 	}
-	var	host_value = null;
+	var	host_value	= null;
 	for(var pos = 0; pos < host_info.length; ++pos){
 		if(!apiutil.isSafeEntity(host_info[pos]) || !apiutil.isSafeString(host_info[pos].key)){
 			r3logger.dlog('Found ip(' + ip + ') with port(' + String(port) + ') in tenant(' + tenant + ') + role(' + role + '), but this host info(' + JSON.stringify(host_info[pos]) + ') is something wrong, skip it');
 			continue;
 		}
 		host_value	= dkcobj.getValue(host_info[pos].key, null, true, null);
-		host_value	= JSON.parse(host_value);
+		host_value	= apiutil.parseJSON(host_value);
 		if(	!apiutil.isSafeEntity(host_value)				||
 			(!apiutil.isSafeString(host_value.hostname) && !apiutil.isSafeString(host_value.ip)) ||	// hostname or ip is existed
 			!apiutil.isSafeEntity(host_value.port)			||
-			apiutil.isEmptyArray(host_value[keys.ID_KW])	||										// host id(array[4])
-			4 !== host_value[keys.ID_KW].length				)
+			!apiutil.isSafeString(host_value[keys.ID_KW])	)
 		{
 			r3logger.dlog('Found ip(' + ip + ') with port(' + String(port) + ') in tenant(' + tenant + ') + role(' + role + '), but this host value(' + JSON.stringify(host_value) + ') is something wrong, skip it');
 		}else{
 			// found safe host info, we use this.
-			host_value.key = host_info[pos].key;
+			host_value.key	= host_info[pos].key;
+			host_value.cuk	= host_info[pos].cuk;
+			host_value.extra= host_info[pos].extra;
 			break;
 		}
 		host_value = null;
@@ -991,13 +1075,26 @@ function rawGetRoleTokenByIP(ip, port, cuk, tenant, role, expire_limit)
 
 	// role id
 	var	role_id	= dkcobj.getValue(role_id_key, null, true, null);
-	role_id		= JSON.parse(role_id);
-	if(apiutil.isEmptyArray(role_id) || role_id.length < 4){
-		resobj.result	= false;
-		resobj.message	= 'could not get role id(' + role_id_key + ') value, or it is wrong value(' + JSON.stringify(role_id) + ').';
-		r3logger.elog(resobj.message);
-		dkcobj.clean();
-		return resobj;
+	if(!apiutil.isSafeStrUuid4(role_id)){
+		var	isError		= false;
+		var	old_role_id	= apiutil.parseJSON(role_id);
+		if(!apiutil.isEmptyArray(old_role_id) && 4 == old_role_id.length){
+			// old version id, so reset new valus(UUID4) here.
+			role_id = apiutil.getStrUuid4();
+			if(!dkcobj.setValue(role_id_key, role_id)){										// set value -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/id
+				isError			= true;
+				resobj.message	= 'could not get role id(' + role_id_key + ') value, because failed to reset new role id instead of old id.';
+			}
+		}else{
+			isError			= true;
+			resobj.message	= 'could not get role id(' + role_id_key + ') value, or it is wrong value(' + JSON.stringify(role_id) + ').';
+		}
+		if(isError){
+			resobj.result	= false;
+			r3logger.elog(resobj.message);
+			dkcobj.clean();
+			return resobj;
+		}
 	}
 
 	// make token value
@@ -1011,8 +1108,9 @@ function rawGetRoleTokenByIP(ip, port, cuk, tenant, role, expire_limit)
 	token_value.hostname= null;																// hostname(null)
 	token_value.ip		= host_value.ip;													// ip(creator)
 	token_value.port	= host_value.port;													// port(creator)
+	token_value.cuk		= host_value.cuk;													// cuk(creator)
+	token_value.extra	= host_value.extra;													// extra(creator)
 	token_value.tenant	= tenant;															// tenant(scope)
-	token_value.base	= host_value[keys.ID_KW];											// host id
 
 	// role token and yrn key
 	var	role_token		= '';
@@ -1020,14 +1118,17 @@ function rawGetRoleTokenByIP(ip, port, cuk, tenant, role, expire_limit)
 
 	// create key
 	for(var is_loop = true; is_loop; ){														// for eslint
-		// set verify value
-		token_value.verify	= apiutil.getRandomBin64();										// random value
-
 		// make role token
-		var	hiBinToken		= apiutil.makeXorValue(token_value.base, token_value.verify);
-		var	lowBinToken		= apiutil.makeXorValue(role_id, token_value.verify);
-		role_token			= apiutil.convertBin64ToHexString(hiBinToken);
-		role_token			+= apiutil.convertBin64ToHexString(lowBinToken);
+		var	token_elements	= apiutil.makeStringToken256(host_value[keys.ID_KW], role_id);
+		if(!apiutil.isSafeEntity(token_elements)){
+			resobj.result	= false;
+			resobj.message	= 'could not make token from ' + JSON.stringify(host_value[keys.ID_KW]) + ' and ' + JSON.stringify(role_id);
+			r3logger.elog(resobj.message);
+			dkcobj.clean();
+			return resobj;
+		}
+		role_token			= token_elements.str_token;
+		token_value.base	= token_elements.str_base;										// token base
 
 		// role token key
 		token_role_key		= keys.TOKEN_ROLE_TOP_KEY + '/' + role_token;					// "yrn:yahoo::::token:role/<role token>"
@@ -1059,6 +1160,18 @@ function rawGetRoleTokenByIP(ip, port, cuk, tenant, role, expire_limit)
 		}
 	}
 
+	// Add token to role tokens key's subkey list
+	subkeylist	= apiutil.getSafeArray(dkcobj.getSubkeys(role_tokens_key, true));
+	if(apiutil.tryAddStringToArray(subkeylist, token_role_key)){
+		if(!dkcobj.setSubkeys(role_tokens_key, subkeylist)){								// add subkey yrn:yahoo::::token:role/<role token> -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/tokens
+			resobj.result	= false;
+			resobj.message	= 'could not add ' + token_role_key + ' subkey under ' + role_tokens_key + ' key';
+			r3logger.elog(resobj.message);
+			dkcobj.clean();
+			return resobj;
+		}
+	}
+
 	// Add role token into result object.
 	resobj.token = role_token;
 
@@ -1073,13 +1186,15 @@ function rawGetRoleTokenByIP(ip, port, cuk, tenant, role, expire_limit)
 // user			:	this value is parsed from user token(or null)
 // tenant		:	this value is parsed from user token(or null)
 // ip			:	client ip address(or null)
+// port			:	port number when ip address parameter exists
+// cuk			:	cuk value when ip address parameter exists
 // 
 // result		:	{
 //						result:		true/false
 //						message:	null or error message string
 // 					}
 // 
-function rawRemoveRoleToken(token, user, tenant, ip)
+function rawRemoveRoleToken(token, user, tenant, ip, port, cuk)
 {
 	var	resobj = {result: true, message: null};
 
@@ -1116,7 +1231,7 @@ function rawRemoveRoleToken(token, user, tenant, ip)
 
 	// get role token value
 	value	= dkcobj.getValue(role_token_key, null, true, null);
-	value	= JSON.parse(value);
+	value	= apiutil.parseJSON(value);
 	if(!apiutil.isSafeEntity(value)){
 		// already role token is removed or expired.
 		r3logger.dlog('could not get role token(' + role_token_key + ') value, or it is wrong value(' + JSON.stringify(value) + '). We check all role token for expire here.');
@@ -1146,8 +1261,7 @@ function rawRemoveRoleToken(token, user, tenant, ip)
 		(!apiutil.isSafeString(value.user) && !apiutil.isSafeString(value.hostname) && !apiutil.isSafeString(value.ip)) ||
 		isNaN(value.port)							||
 		!apiutil.isSafeString(value.tenant)			||
-		apiutil.isEmptyArray(value.base)			||
-		4 !== value.base.length						)
+		!apiutil.isSafeString(value.base)			)
 	{
 		//
 		// Not check expired token and ip address is empty here.
@@ -1168,17 +1282,45 @@ function rawRemoveRoleToken(token, user, tenant, ip)
 		return resobj;
 	}
 
+	// keep role tokens key for removing key in its subkey list.
+	var	role_tokens_key = value.role + '/' + keys.ROLE_TOKEN_KW;							// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/tokens"
+
 	// check requester
 	if(apiutil.isSafeString(ip)){
-		// check ip address
+		// check ip address bases
 		//
+		// port
+		if(!isNaN(port)){
+			port = parseInt(port);
+		}else{
+			port = 0;
+		}
+		// cuk
+		if(apiutil.isSafeString(cuk) && apiutil.isSafeString(cuk.trim())){
+			cuk = cuk.trim();
+		}else{
+			cuk = null;
+		}
+
+		// check
+		if(	value.port != port													||
+			apiutil.isSafeString(value.cuk) != apiutil.isSafeString(cuk)		||
+			(apiutil.isSafeString(value.cuk) && value.cuk != cuk)				)
+		{
+			resobj.result	= false;
+			resobj.message	= 'could not remove role token(' + token + '), because port(' + JSON.stringify(port) + ' vs ' + JSON.stringify(value.port) + ')/cuk(' + JSON.stringify(cuk) + ' vs ' + JSON.stringify(value.cuk) + ') value is not same.';
+			r3logger.elog(resobj.message);
+			dkcobj.clean();
+			return resobj;
+		}
+
 		// [NOTE]
 		// findHost() is creating k2hdkc object in it, thus we close dkc object here.
 		// and re-create dkc object after returning that function.
 		//
 		dkcobj.clean();
 
-		var	find_result = k2hr3.findHost(value.tenant, value.role, null, ip, 0);			// port = any
+		var	find_result = k2hr3.findHost(value.tenant, value.role, null, ip, port, cuk, false);	// not strict checking
 		if(!find_result.result || apiutil.isEmptyArray(find_result.host_info)){
 			// ip address is not member of role
 			resobj.result	= false;
@@ -1219,7 +1361,379 @@ function rawRemoveRoleToken(token, user, tenant, ip)
 		}
 	}
 
+	// remove token key from role's tokens subkey.
+	subkeylist = apiutil.getSafeArray(dkcobj.getSubkeys(role_tokens_key, true));
+	if(apiutil.removeStringFromArray(subkeylist, role_token_key)){
+		if(!dkcobj.setSubkeys(role_tokens_key, subkeylist)){								// update subkey -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/tokens
+			resobj.result	= false;
+			resobj.message	= 'could not update subkey under ' + role_tokens_key + ' key';
+			r3logger.elog(resobj.message);
+			dkcobj.clean();
+			return resobj;
+		}
+	}
+
 	dkcobj.clean();
+	return resobj;
+}
+
+//---------------------------------------------------------
+// Remove Role Tokens Directly
+//---------------------------------------------------------
+// dkcobj_permanent	:	dkcobj object
+// tokens			:	array to role token yrn path
+// 
+// result			:	true/false
+// 
+function rawDirectRemoveRoleTokens(dkcobj_permanent, tokens)
+{
+	if(!(dkcobj_permanent instanceof Object) || !dkcobj_permanent.isPermanent()){
+		r3logger.elog('dkcobj_parameters are wrong : dkcobj_permanent=' + JSON.stringify(dkcobj_permanent));
+		return false;
+	}
+	if(apiutil.isSafeString(tokens)){
+		tokens = [tokens];
+	}
+	if(apiutil.isEmptyArray(tokens)){
+		r3logger.dlog('tokens(' + JSON.stringify(tokens) + ') is empty or not array');
+		return true;
+	}
+
+	//
+	// Keys
+	//
+	var	keys		= r3keys();
+	var	subkeylist	= dkcobj_permanent.getSubkeys(keys.TOKEN_ROLE_TOP_KEY, true);			// get subkeys under "yrn:yahoo::::token:role"
+	var	matchptn	= keys.TOKEN_ROLE_TOP_KEY + '/';										// matching pattern "yrn:yahoo::::token:role/"
+	var	needupdate	= false;
+
+	// remove each token
+	for(var cnt = 0; cnt < tokens.length; ++cnt){
+		if(!apiutil.isSafeString(tokens[cnt])){
+			r3logger.elog('token(' + JSON.stringify(tokens[cnt]) + ') yrn path is not string, but continue...');
+			continue;
+		}
+		if(0 !== tokens[cnt].indexOf(matchptn)){
+			r3logger.elog('token(' + JSON.stringify(tokens[cnt]) + ') is not full yrn path, but continue...');
+			continue;
+		}
+
+		// remove token
+		if(!dkcobj_permanent.remove(tokens[cnt], false)){									// remove yrn:yahoo::::token:role/<role token>
+			r3logger.elog('failed to remove token(' + JSON.stringify(tokens[cnt]) + '), but continue...');
+		}else{
+			// remove token from subkeys(token top key)
+			if(apiutil.removeStringFromArray(subkeylist, tokens[cnt])){
+				needupdate = true;
+			}
+		}
+	}
+	if(needupdate){
+		if(!dkcobj_permanent.setSubkeys(keys.TOKEN_ROLE_TOP_KEY, subkeylist)){				// update subkey -> yrn:yahoo::::token:role
+			r3logger.elog('failed to reset role token subkeys to ' + keys.TOKEN_ROLE_TOP_KEY + ' top key, but continue...');
+		}
+	}
+	return true;
+}
+
+//---------------------------------------------------------
+// Remove Role Token with checking tenant
+//---------------------------------------------------------
+// token_string	:	role token string
+// tenant		:	tenant name
+// 
+// result		:	true/false
+// 
+function rawRemoveRoleTokenByPath(token_string, tenant)
+{
+	if(!apiutil.isSafeStrings(token_string, tenant)){
+		r3logger.elog('token_string(' + JSON.stringify(token_string) + ') or tenant(' + JSON.stringify(tenant) + ') parameter is something wrong.');
+		return false;
+	}
+
+	//
+	// Keys
+	//
+	var	keys			= r3keys(null, tenant);
+	var	role_token_key	= keys.TOKEN_ROLE_TOP_KEY + '/' + token_string;						// role token path "yrn:yahoo::::token:role/<token>"
+
+	var	dkcobj			= k2hr3.getK2hdkc(true, false);										// use permanent object(need to clean)
+	if(!apiutil.isSafeEntity(dkcobj)){
+		r3logger.elog('Not initialize yet.');
+		return false;
+	}
+
+	// get token value
+	var	value	= dkcobj.getValue(role_token_key, null, true, null);
+	value		= apiutil.parseJSON(value);
+	if(	!apiutil.isSafeEntity(value)				||
+		!apiutil.isSafeString(value.role)			||
+		!apiutil.isSafeString(value.date)			||
+		!apiutil.isSafeString(value.expire)			||
+		!apiutil.isSafeString(value.creator)		||
+		(!apiutil.isSafeString(value.user) && !apiutil.isSafeString(value.hostname) && !apiutil.isSafeString(value.ip)) ||
+		isNaN(value.port)							||
+		!apiutil.isSafeString(value.tenant)			||
+		!apiutil.isSafeString(value.base)			)
+	{
+		r3logger.elog('could not get role role_token_key(' + role_token_key + ') value, or it is wrong value(' + JSON.stringify(value) + ') or already expired.');
+		dkcobj.clean();
+		return false;
+	}
+
+	// check tenant name
+	var	roleptn		= new RegExp('^' + keys.MATCH_ANY_TENANT_ROLE);							// regex = /^yrn:yahoo:(.*)::(.*):role:(.*)/
+	var	rolematchs	= value.role.match(roleptn);
+	if(apiutil.isEmptyArray(rolematchs) || rolematchs.length < 4){
+		// token's role is not matched role yrn
+		r3logger.elog('role path(' + JSON.stringify(value.role) + ') in role token(' + role_token_key + ') value is not role yrn full path.');
+		dkcobj.clean();
+		return false;
+	}
+	if(tenant !== rolematchs[2]){
+		// tenant name is not matched.
+		r3logger.elog('tenant name(' + JSON.stringify(rolematchs[2]) + ') in role token(' + role_token_key + ') value is not as same as specified tenant(' + JSON.stringify(tenant) + ').');
+		dkcobj.clean();
+		return false;
+	}
+
+	// remove token
+	if(!dkcobj.remove(role_token_key, false)){												// remove yrn:yahoo::::token:role/<role token>
+		r3logger.elog('failed to remove token(' + JSON.stringify(role_token_key) + ').');
+		dkcobj.clean();
+		return false;
+	}
+
+	// remove token from subkeys(token top key)
+	var	subkeylist = dkcobj.getSubkeys(keys.TOKEN_ROLE_TOP_KEY, true);						// get subkeys under "yrn:yahoo::::token:role"
+	if(apiutil.removeStringFromArray(subkeylist, role_token_key)){
+		// update subkey
+		if(!dkcobj.setSubkeys(keys.TOKEN_ROLE_TOP_KEY, subkeylist)){						// update subkey -> yrn:yahoo::::token:role
+			r3logger.elog('failed to reset role token subkeys to ' + keys.TOKEN_ROLE_TOP_KEY + ' top key, but continue...');
+		}
+	}
+
+	// remove token key from role's tokens subkey.
+	var	role_tokens_key = value.role + '/' + keys.ROLE_TOKEN_KW;							// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/tokens"
+	subkeylist = apiutil.getSafeArray(dkcobj.getSubkeys(role_tokens_key, true));
+	if(apiutil.removeStringFromArray(subkeylist, role_token_key)){
+		if(!dkcobj.setSubkeys(role_tokens_key, subkeylist)){								// update subkey -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/tokens
+			r3logger.elog('could not update subkey under ' + role_tokens_key + ' key, but continue...');
+		}
+	}
+
+	dkcobj.clean();
+	return true;
+}
+
+//---------------------------------------------------------
+// Get List of Role Tokens
+//---------------------------------------------------------
+// role			:	role yrn full path or role name(path)
+// tenant		:	for checking role full yrn path
+// expand		:	whether to expand token information(default false)
+//
+// result		:	not expand
+//					{
+//						result:		true/false
+//						message:	null or error message string
+//						tokens: [
+//							"role token",
+//							....
+//						]
+// 					}
+//
+// result		:	expand
+//					{
+//						result:		true/false
+//						message:	null or error message string
+//						tokens:	{
+//							"token": {
+//								date:		create date(UTC ISO 8601)
+//								expire:		expire date(UTC ISO 8601)
+//								user:		user name if user created this token
+//								hostname:	hostname if this token was created by host(name)
+//								ip:			ip address if this token was created by ip
+//								port:		port number, if specified port when created token
+//								cuk:		cuk, if specified cuk when created token
+//							},
+//							...
+//						}
+// 					}
+// 
+function rawGetListRoleTokens(role, tenant, expand)
+{
+	var	resobj = {result: true, message: null};
+
+	if(!apiutil.isSafeStrings(role, tenant)){
+		resobj.result	= false;
+		resobj.message	= 'role(' + JSON.stringify(role) + '), tenant(' + JSON.stringify(tenant) + ') parameters are wrong.';
+		r3logger.elog(resobj.message);
+		return resobj;
+	}
+	if('boolean' != typeof expand){
+		expand = false;
+	}
+
+	// check role is full yrn path and tenant
+	var	keys		= r3keys(null, tenant);
+	var	roleptn		= new RegExp('^' + keys.MATCH_ANY_TENANT_ROLE);		// regex = /^yrn:yahoo:(.*)::(.*):role:(.*)/
+	var	rolematchs	= role.match(roleptn);
+	if(apiutil.isEmptyArray(rolematchs) || rolematchs.length < 4){
+		// role is not full yrn
+		resobj.result	= false;
+		resobj.message	= 'role(' + JSON.stringify(role) + ') is nor full yrn path.';
+		r3logger.elog(resobj.message);
+		return resobj;
+	}else{
+		// role is full yrn to role
+		if(!apiutil.compareCaseString(rolematchs[2], tenant)){
+			resobj.result	= false;
+			resobj.message	= 'tenant(' + JSON.stringify(tenant) + ') is not as same as tenant in role(' + JSON.stringify(role) + ') full yrn.';
+			r3logger.elog(resobj.message);
+			return resobj;
+		}
+	}
+
+	var	dkcobj			= k2hr3.getK2hdkc(true, false);					// use permanent object(need to clean)
+	if(!apiutil.isSafeEntity(dkcobj)){
+		resobj.result	= false;
+		resobj.message	= 'Not initialize yet.';
+		r3logger.elog(resobj.message);
+		return resobj;
+	}
+
+	// check role path(check id key under role key)
+	var	id_key	= role + '/' + keys.ID_KW;							// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/id"
+	var	value	= dkcobj.getValue(id_key, null, true, null);
+	if(!apiutil.isSafeString(value)){
+		resobj.result	= false;
+		resobj.message	= 'role(' + JSON.stringify(role) + ') does not exist';
+		r3logger.elog(resobj.message);
+		dkcobj.clean();
+		return resobj;
+	}
+
+	// get all role tokens
+	var	tokens_key	= role + '/' + keys.ROLE_TOKEN_KW;					// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/tokens"
+	var	tokenlist	= dkcobj.getSubkeys(tokens_key, true);
+	if(expand){
+		// get each token information
+		resobj.tokens = rawGetDirectRoleTokenInfo(dkcobj, tokenlist);
+		if(null == resobj.tokens){
+			resobj.tokens = {};
+		}
+	}else{
+		// set token list
+		resobj.tokens	= [];
+
+		if(apiutil.isEmptyArray(tokenlist)){							// token list is full yrn path
+			tokenlist = [];
+		}
+		var	tokenptn = new RegExp('^' + keys.MATCH_ANY_ROLE_TOKEN);		// regex = /^yrn:yahoo::::token:role\/(.*)/
+		for(var cnt = 0; cnt < tokenlist.length; ++cnt){
+			if(!apiutil.isSafeString(tokenlist[cnt])){
+				r3logger.wlog('Found wrong token string(' + JSON.stringify(tokenlist[cnt]) + ') in token list, skip this.');
+			}else{
+				var	tokenmatches = tokenlist[cnt].match(tokenptn);
+				if(!apiutil.isEmptyArray(tokenmatches) && 2 <= tokenmatches.length && apiutil.isSafeString(tokenmatches[1])){
+					resobj.tokens.push(tokenmatches[1]);
+				}else{
+					r3logger.wlog('Found wrong token string(' + JSON.stringify(tokenlist[cnt]) + ') in token list, skip this.');
+				}
+			}
+		}
+	}
+
+	dkcobj.clean();
+	return resobj;
+}
+
+//---------------------------------------------------------
+// Get Role Token Directly
+//---------------------------------------------------------
+// dkcobj_permanent	:	dkcobj object
+// tokens			:	array to role token yrn path
+// 
+// result			:	{
+//							"token": {
+//								date:		create date(UTC ISO 8601)
+//								expire:		expire date(UTC ISO 8601)
+//								user:		user name if user created this token
+//								hostname:	hostname if this token was created by host(name)
+//								ip:			ip address if this token was created by ip
+//								port:		port number, if specified port when created token
+//								cuk:		cuk, if specified cuk when created token
+//							},
+//							...
+//						}
+//						or null(if error)
+//
+function rawGetDirectRoleTokenInfo(dkcobj_permanent, tokens)
+{
+	if(!(dkcobj_permanent instanceof Object) || !dkcobj_permanent.isPermanent()){
+		r3logger.elog('dkcobj_parameters are wrong : dkcobj_permanent=' + JSON.stringify(dkcobj_permanent));
+		return null;
+	}
+	if(apiutil.isSafeString(tokens)){
+		tokens = [tokens];
+	}
+	if(apiutil.isEmptyArray(tokens)){
+		r3logger.dlog('tokens(' + JSON.stringify(tokens) + ') is empty or not array');
+		return null;
+	}
+
+	//
+	// Keys
+	//
+	var	keys		= r3keys();
+	var	matchptn	= keys.TOKEN_ROLE_TOP_KEY + '/';										// matching pattern "yrn:yahoo::::token:role/"
+	var	resobj		= {};
+	for(var cnt = 0; cnt < tokens.length; ++cnt){
+		// check role token path and split token string
+		if(!apiutil.isSafeString(tokens[cnt])){
+			r3logger.elog('token(' + JSON.stringify(tokens[cnt]) + ') yrn path is not string, but continue...');
+			continue;
+		}
+		if(0 !== tokens[cnt].indexOf(matchptn)){
+			r3logger.elog('token(' + JSON.stringify(tokens[cnt]) + ') is not full yrn path, but continue...');
+			continue;
+		}
+		var	token_key = tokens[cnt].split(matchptn)[1];
+
+		// get/check role token value
+		var	value	= dkcobj_permanent.getValue(tokens[cnt], null, true, null);
+		value		= apiutil.parseJSON(value);
+		if(	!apiutil.isSafeEntity(value)				||
+			!apiutil.isSafeString(value.role)			||
+			!apiutil.isSafeString(value.date)			||
+			!apiutil.isSafeString(value.expire)			||
+			!apiutil.isSafeString(value.creator)		||
+			(!apiutil.isSafeString(value.user) && !apiutil.isSafeString(value.hostname) && !apiutil.isSafeString(value.ip)) ||
+			isNaN(value.port)							||
+			!apiutil.isSafeString(value.tenant)			||
+			!apiutil.isSafeString(value.base)			)
+		{
+			r3logger.dlog('could not get role token(' + tokens[cnt] + ') value, or it is wrong value(' + JSON.stringify(value) + ') or expired, thus skip this.');
+			continue;
+		}
+
+		// check expire by token value
+		if(apiutil.isExpired(value.expire)){
+			// expired
+			continue;
+		}
+
+		// delete unnecessary keys
+		delete value.role;
+		delete value.creator;
+		delete value.tenant;
+		delete value.base;
+		delete value.extra;
+
+		// add result
+		resobj[token_key] = value;
+	}
 	return resobj;
 }
 
@@ -1228,6 +1742,9 @@ function rawRemoveRoleToken(token, user, tenant, ip)
 //---------------------------------------------------------
 // token		:	role token
 // ip			:	client ip address
+// port			:	if is_strict is true, check port number
+// cuk			:	if is_strict is true, check cuk
+// is_strict	:	true means strict checking
 // 
 // result		:	null or token information
 //					{
@@ -1236,16 +1753,30 @@ function rawRemoveRoleToken(token, user, tenant, ip)
 //						hostname:	null or host name
 //						ip:			null or ip address
 //						port:		port number(if host is existed), 0 means any
+//						cuk:		cuk(allowed null)
+//						extra:		extra(allowed null)
 //						tenant:		tenant name
 //						scoped:		role token is always scoped(true)
 //						region:		role token is always null
 //					}
 // 
-function rawCheckRoleToken(token, ip)
+function rawCheckRoleToken(token, ip, port, cuk, is_strict)
 {
 	if(!apiutil.isSafeString(token)){
 		r3logger.elog('some parameters are wrong : token=' + JSON.stringify(token));
 		return null;
+	}
+	if(!apiutil.isSafeEntity(port)){
+		port = 0;
+	}else if(isNaN(port)){
+		r3logger.elog('port(' + JSON.stringify(port) + ') parameter is wrong.');
+		return null;
+	}
+	if(!apiutil.isSafeString(cuk)){
+		cuk = null;
+	}
+	if('boolean' != typeof is_strict){
+		is_strict = false;
 	}
 
 	var	dkcobj			= k2hr3.getK2hdkc(true, false);										// use permanent object(need to clean)
@@ -1262,7 +1793,7 @@ function rawCheckRoleToken(token, ip)
 
 	// get role token value
 	value	= dkcobj.getValue(role_token_key, null, true, null);
-	value	= JSON.parse(value);
+	value	= apiutil.parseJSON(value);
 	if(!apiutil.isSafeEntity(value)){
 		r3logger.dlog('could not get role token(' + role_token_key + ') value, or it is wrong value(' + JSON.stringify(value) + '). We check all role token for expire here.');
 		dkcobj.clean();
@@ -1288,8 +1819,7 @@ function rawCheckRoleToken(token, ip)
 		(!apiutil.isSafeString(value.user) && !apiutil.isSafeString(value.hostname) && !apiutil.isSafeString(value.ip)) ||
 		isNaN(value.port)							||
 		!apiutil.isSafeString(value.tenant)			||
-		apiutil.isEmptyArray(value.base)			||
-		4 !== value.base.length						)
+		!apiutil.isSafeString(value.base)			)
 	{
 		//
 		// Not check expired token and ip address is empty here.
@@ -1306,6 +1836,17 @@ function rawCheckRoleToken(token, ip)
 			dkcobj.clean();
 			return null;
 		}
+		// strict checking
+		if(is_strict){
+			if(	value.port != port													||
+				!apiutil.isSafeString(value.cuk) != apiutil.isSafeString(cuk)		||
+				(apiutil.isSafeString(value.cuk) && value.cuk != cuk)				)
+			{
+				r3logger.dlog('failed strictly checking role token(' + role_token_key + ').');
+				dkcobj.clean();
+				return null;
+			}
+		}
 	}
 
 	// check expire
@@ -1315,13 +1856,40 @@ function rawCheckRoleToken(token, ip)
 		return null;
 	}
 
+	// get seed id(user id or host(ip) id)
+	var	seed_id = null;
+	if(!apiutil.isSafeString(value.user)){
+		// creator is host(ip), then get it's id
+		var	host_value	= dkcobj.getValue(value.creator, null, true, null);					// get value from "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/hosts/ip/<ip:port>"
+		host_value		= apiutil.parseJSON(host_value);
+		if(	!apiutil.isSafeEntity(host_value)				||
+			(!apiutil.isSafeString(host_value.hostname) && !apiutil.isSafeString(host_value.ip)) ||	// hostname or ip is existed
+			!apiutil.isSafeEntity(host_value.port)			||
+			!apiutil.isSafeString(host_value[keys.ID_KW])	)
+		{
+			r3logger.dlog('could not get host or ip(' + value.creator + ') value, or it is wrong value(' + JSON.stringify(host_value) + ').');
+			dkcobj.clean();
+			return null;
+		}
+		seed_id = host_value[keys.ID_KW];
+
+	}else{
+		// creator is user, then get user's id
+		var	user_id_key	= value.creator + ':' + keys.ID_KW;									// "yrn:yahoo::::user:<user name>:id"
+		seed_id			= dkcobj.getValue(user_id_key, null, true, null);
+		if(!apiutil.isSafeString(seed_id)){
+			r3logger.dlog('could not get user id(' + user_id_key + ') value, or it is wrong value(' + JSON.stringify(seed_id) + ').');
+			dkcobj.clean();
+			return null;
+		}
+	}
+
 	// get role id for verify
 	keys				= r3keys(null, value.tenant);										// remake keys
 	var	role_key		= value.role;														// role member is full yrn => "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}"
 	var	role_id_key		= role_key + '/' + keys.ID_KW;										// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/id"
 	var	role_id			= dkcobj.getValue(role_id_key, null, true, null);
-	role_id				= JSON.parse(role_id);
-	if(apiutil.isEmptyArray(role_id) || role_id.length < 4){
+	if(!apiutil.isSafeStrUuid4(role_id)){
 		r3logger.dlog('could not get role id(' + role_id_key + ') value, or it is wrong value(' + JSON.stringify(role_id) + '), maybe expired this token');
 		dkcobj.clean();
 		return null;
@@ -1329,10 +1897,15 @@ function rawCheckRoleToken(token, ip)
 	dkcobj.clean();
 
 	// make verify token
-	var	verifyval		= apiutil.convertBin64ToHexString(apiutil.makeXorValue(value.base, value.verify));
-	verifyval			+= apiutil.convertBin64ToHexString(apiutil.makeXorValue(role_id, value.verify));
-	if(token !== verifyval){
-		r3logger.elog('token(' + token + ') verify is failure, verify token is ' + verifyval + '.');
+	var	token_elements	= apiutil.makeStringToken256(seed_id, role_id, value.base);
+	if(!apiutil.isSafeEntity(token_elements)){
+		r3logger.dlog('could not make verify token from ' + JSON.stringify(seed_id) + ' and ' + JSON.stringify(role_id) + ' and ' + JSON.stringify(value.base));
+		dkcobj.clean();
+		return null;
+	}
+	if(token !== token_elements.str_token){
+		r3logger.elog('token(' + token + ') verify is failure, verify token is ' + token_elements.str_token + '.');
+		dkcobj.clean();
 		return null;
 	}
 
@@ -1343,6 +1916,8 @@ function rawCheckRoleToken(token, ip)
 	token_info.hostname	= value.hostname;													// hostname
 	token_info.ip		= value.ip;
 	token_info.port		= value.port;
+	token_info.cuk		= value.cuk;
+	token_info.extra	= value.extra;
 	token_info.tenant	= value.tenant;
 	token_info.scoped	= true;																// role token is always scoped
 	token_info.region	= null;
@@ -1378,7 +1953,7 @@ function rawCleanupUserToken(callback)
 	var	retrive_skeys	= new Array(0);
 	for(var cnt = 0; cnt < subkeylist.length; ++cnt){
 		var	user_token_key = dkcobj.getValue(subkeylist[cnt], null, true, null);
-		if(!apiutil.isSafeStrings(user_token_key)){
+		if(!apiutil.isSafeString(user_token_key)){
 			// value is not existed, so this key should be removing
 			retrive_skeys.push(subkeylist[cnt]);
 		}else{
@@ -1386,13 +1961,13 @@ function rawCleanupUserToken(callback)
 			// user_token_key => "yrn:yahoo::::user:<user>:tenant/{<tenant>}/token/<token>"
 			//
 			var	value = dkcobj.getValue(user_token_key, null, true, null);
-			if(!apiutil.isSafeStrings(value)){
+			if(!apiutil.isSafeString(value)){
 				// user_token_key is not existed or expired.
 				retrive_skeys.push(subkeylist[cnt]);
 
 				// try remove user_token_key from "yrn:yahoo::::user:<user>:tenant/{<tenant>}/token" subkey list
 				var	parent_user_key = apiutil.getParentPath(user_token_key);
-				if(apiutil.isSafeStrings(parent_user_key)){
+				if(apiutil.isSafeString(parent_user_key)){
 					var	user_skeys = dkcobj.getSubkeys(parent_user_key, true);				// get subkeys under "yrn:yahoo::::user:<user>:tenant/{<tenant>}/token"
 					if(apiutil.removeStringFromArray(user_skeys, user_token_key)){
 						if(!dkcobj.setSubkeys(parent_user_key, user_skeys)){				// update subkey -> "yrn:yahoo::::user:<user>:tenant/{<tenant>}/token"
@@ -1456,14 +2031,38 @@ function rawCleanupRoleToken(callback)
 	var	subkeylist		= dkcobj.getSubkeys(keys.TOKEN_ROLE_TOP_KEY, true);					// get subkeys under "yrn:yahoo::::token:role"
 	var	is_changed		= false;
 	var	newsubkeylist	= new Array(0);
+
 	for(var cnt = 0; cnt < subkeylist.length; ++cnt){
-		var	value = dkcobj.getValue(subkeylist[cnt], null, true, null);
-		if(!apiutil.isSafeStrings(value)){
+		var	role_tokens_key;
+
+		// not use attributes for getting role path
+		var	value	= dkcobj.getValue(subkeylist[cnt], null, false, null);
+		value		= apiutil.parseJSON(value);
+		if(apiutil.isSafeEntity(value) && apiutil.isSafeString(value.role)){
+			role_tokens_key = value.role + '/' + keys.ROLE_TOKEN_KW;						// "yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/tokens"
+		}else{
+			role_tokens_key = null;
+		}
+
+		// use attributes for getting role path
+		value		= dkcobj.getValue(subkeylist[cnt], null, true, null);
+		if(!apiutil.isSafeString(value)){
 			is_changed	= true;
+
+			// remove role token from role's tokens subkey
+			if(null !== role_tokens_key){
+				var	tokenlist = apiutil.getSafeArray(dkcobj.getSubkeys(role_tokens_key, true));
+				if(apiutil.removeStringFromArray(tokenlist, subkeylist[cnt])){
+					if(!dkcobj.setSubkeys(role_tokens_key, tokenlist)){						// update subkey -> yrn:yahoo:<service>::<tenant>:role:<role>{/<role>{...}}/tokens
+						r3logger.elog('could not update subkey under ' + role_tokens_key + ' key, but continue...');
+					}
+				}
+			}
 		}else{
 			newsubkeylist.push(subkeylist[cnt]);
 		}
 	}
+
 	if(false === is_changed){
 		dkcobj.clean();
 		callback(true);
@@ -1488,7 +2087,7 @@ function rawCleanupRoleToken(callback)
 //
 function rawGetUserTenantByToken(token)
 {
-	if(!apiutil.isSafeStrings(token)){
+	if(!apiutil.isSafeString(token)){
 		r3logger.elog('token parameters are wrong : token=' + JSON.stringify(token));
 		return null;
 	}
@@ -1607,7 +2206,7 @@ function rawGetTenantListByUserWithDkc(dkcobj_permanent, user)
 		r3logger.elog('dkcobj_parameters are wrong : dkcobj_permanent=' + JSON.stringify(dkcobj_permanent));
 		return null;
 	}
-	if(!apiutil.isSafeStrings(user)){
+	if(!apiutil.isSafeString(user)){
 		r3logger.elog('user parameters are wrong : user=' + JSON.stringify(user));
 		return null;
 	}
@@ -1811,6 +2410,8 @@ function rawCheckTenantInTenantList(tenants, tenant)
 //						hostname:	null or host name
 //						ip:			null or host ip address
 //						port:		port number(if host is existed), 0 means any
+//						cuk:		cuk(allowed null)
+//						extra:		extra(allowed null)
 //						tenant:		tenant name
 //						scoped:		role token is always scoped(true)
 //					}
@@ -1878,7 +2479,8 @@ function rawCheckToken(req, is_scoped, is_user)
 		// we set always ip address to token(and role/hosts) value now.
 		// then we do not need to convert ip to hostname here.
 		//
-		token_info = rawCheckRoleToken(token, ip);
+
+		token_info = rawCheckRoleToken(token, ip);				// not strictly checking
 		if(null === token_info || !apiutil.isSafeEntity(token_info.role)){
 			resobj.result	= false;
 			resobj.message	= 'token(' + token + ') is not existed, because it is expired or not set yet.';
@@ -2034,9 +2636,9 @@ exports.checkUserToken = function(token)
 	return rawCheckUserToken(token);
 };
 
-exports.getRoleTokenByUser = function(user, tenant, base_id, role, expire_limit)
+exports.getRoleTokenByUser = function(user, tenant, role, expire_limit)
 {
-	return rawGetRoleTokenByUser(user, tenant, base_id, role, expire_limit);
+	return rawGetRoleTokenByUser(user, tenant, role, expire_limit);
 };
 
 exports.getRoleTokenByIP = function(ip, port, cuk, tenant, role, expire_limit)
@@ -2046,17 +2648,37 @@ exports.getRoleTokenByIP = function(ip, port, cuk, tenant, role, expire_limit)
 
 exports.removeRoleTokenByUser = function(token, user, tenant)
 {
-	return rawRemoveRoleToken(token, user, tenant, null);
+	return rawRemoveRoleToken(token, user, tenant, null, 0, null, null);
 };
 
-exports.removeRoleTokenByIP = function(token, ip)
+exports.directRemoveRoleTokens = function(dkcobj_permanent, tokens)
 {
-	return rawRemoveRoleToken(token, null, null, ip);
+	return rawDirectRemoveRoleTokens(dkcobj_permanent, tokens);
 };
 
-exports.checkRoleToken = function(token, ip)
+exports.removeRoleTokenByPath = function(token_string, tenant)
 {
-	return rawCheckRoleToken(token, ip);
+	return rawRemoveRoleTokenByPath(token_string, tenant);
+};
+
+exports.getListRoleTokens = function(role, tenant, expand)
+{
+	return rawGetListRoleTokens(role, tenant, expand);
+};
+
+exports.getDirectRoleTokenInfo = function(dkcobj_permanent, tokens)
+{
+	return rawGetDirectRoleTokenInfo(dkcobj_permanent, tokens);
+};
+
+exports.removeRoleTokenByIP = function(token, ip, port, cuk)
+{
+	return rawRemoveRoleToken(token, null, null, ip, port, cuk);
+};
+
+exports.checkRoleToken = function(token, ip, port, cuk, is_strict)
+{
+	return rawCheckRoleToken(token, ip, port, cuk, is_strict);
 };
 
 exports.getTenantListWithDkc = function(dkcobj_permanent, user)

--- a/lib/openstackapiv2.js
+++ b/lib/openstackapiv2.js
@@ -72,21 +72,25 @@ var r3logger	= require('../lib/dbglogging');
 //
 // callback(error, result):
 //				result = {
-//					user:	user name										(*3)
-//					userid:	user id											(*4)
-//					scoped:	false											(always false)
-//					token:	token string(id)								(*1)
-//					expire:	expire string									(*2)
-//					region:	region string									(region name for keystone endpoint)
+//					user:		user name									(*3)
+//					userid:		user id										(*4)
+//					scoped:		false										(always false)
+//					token:		token string(id)							(*1)
+//					expire:		expire string								(*2)
+//					region:		region string								(region name for keystone endpoint)
+//					token_seed:	seed										({publisher: 'OPENSTACKV2'})
 //				}
 //
 function rawGetUserUnscopedTokenV2(uname, passwd, callback)
 {
-	if(!apiutil.isSafeStrings(uname, passwd)){
-		var	error = new Error('some parameters are wrong : uname=' + JSON.stringify(uname) + ', passwd=<not printed>');
+	if(!apiutil.isSafeString(uname)){
+		var	error = new Error('some parameters are wrong : uname=' + JSON.stringify(uname));
 		r3logger.elog(error.message);
 		callback(error, null);
 		return;
+	}
+	if(!apiutil.isSafeString(passwd)){
+		passwd = null;
 	}
 	var	_uname		= uname;
 	var	_passwd		= passwd;
@@ -186,14 +190,18 @@ function rawGetUserUnscopedTokenV2(uname, passwd, callback)
 					return;
 				}
 
+				// convert openstack user id(16 bytes hex string) to UUID(not UUID4)
+				var	user_id_uuid4	= apiutil.cvtNumberStringToUuid4(res_body.access.user.id, 16);
+
 				// build result
-				var	resobj		= {};
-				resobj.user		= res_body.access.user.name.toLowerCase();
-				resobj.userid	= res_body.access.user.id.toLowerCase();
-				resobj.scoped	= false;
-				resobj.token	= res_body.access.token.id.toLowerCase();
-				resobj.expire	= res_body.access.token.expires;
-				resobj.region	= keystone_ep.region.toLowerCase();
+				var	resobj			= {};
+				resobj.user			= res_body.access.user.name.toLowerCase();
+				resobj.userid		= user_id_uuid4;
+				resobj.scoped		= false;
+				resobj.token		= res_body.access.token.id.toLowerCase();
+				resobj.expire		= res_body.access.token.expires;
+				resobj.region		= keystone_ep.region.toLowerCase();
+				resobj.token_seed	= JSON.stringify({ publisher: 'OPENSTACKV2' });
 				_callback(null, resobj);
 			});
 		});
@@ -279,12 +287,13 @@ function rawGetUserUnscopedTokenV2(uname, passwd, callback)
 //
 // callback(error, result):
 //				result = {
-//					user:	user name										(*3)
-//					userid:	user id											(*4)
-//					scoped:	true											(always true)
-//					token:	token string(id)								(*1)
-//					expire:	expire string									(*2)
-//					region:	region string									(identity's *4 for region name)
+//					user:		user name									(*3)
+//					userid:		user id										(*4)
+//					scoped:		true										(always true)
+//					token:		token string(id)							(*1)
+//					expire:		expire string								(*2)
+//					region:		region string								(identity's *4 for region name)
+//					token_seed:	seed										({publisher: 'OPENSTACKV2'})
 //				}
 //
 function rawGetUserScopedTokenV2(unscopedtoken, tenant, callback)
@@ -435,14 +444,18 @@ function rawGetUserScopedTokenV2(unscopedtoken, tenant, callback)
 					return;
 				}
 
+				// convert openstack user id(16 bytes hex string) to UUID(not UUID4)
+				var	user_id_uuid4	= apiutil.cvtNumberStringToUuid4(res_body.access.user.id, 16);
+
 				// build result
-				var	resobj		= {};
-				resobj.user		= res_body.access.user.name.toLowerCase();
-				resobj.userid	= res_body.access.user.id.toLowerCase();
-				resobj.scoped	= true;
-				resobj.token	= res_body.access.token.id.toLowerCase();
-				resobj.expire	= res_body.access.token.expires;
-				resobj.region	= region.toLowerCase();
+				var	resobj			= {};
+				resobj.user			= res_body.access.user.name.toLowerCase();
+				resobj.userid		= user_id_uuid4;
+				resobj.scoped		= true;
+				resobj.token		= res_body.access.token.id.toLowerCase();
+				resobj.expire		= res_body.access.token.expires;
+				resobj.region		= region.toLowerCase();
+				resobj.token_seed	= JSON.stringify({ publisher: 'OPENSTACKV2' });
 				_callback(null, resobj);
 			});
 		});
@@ -456,6 +469,71 @@ function rawGetUserScopedTokenV2(unscopedtoken, tenant, callback)
 		req.write(strbody);
 		req.end();
 	}, false);
+}
+
+//
+// Verify User Token for OpenStack V2
+//
+// user				:	target user name for token
+// token			:	check token
+// token_seed		:	token seed data
+//
+// result			:	{
+//							result:		true/false
+//							message:	null or error message string
+// 						}
+// 
+function rawVerifyUserTokenPublisherV2(token_seed)
+{
+	if(!apiutil.isSafeString(token_seed)){
+		return false;
+	}
+
+	// parse seed
+	var	seed = token_seed;
+	if(apiutil.checkSimpleJSON(token_seed)){
+		seed = JSON.parse(token_seed);
+	}
+	if(	!apiutil.isSafeEntity(seed)				||
+		!apiutil.isSafeString(seed.publisher)	||
+		(seed.publisher != 'OPENSTACKV2')		)		// publisher must be 'OPENSTACKV2'
+	{
+		return false;
+	}
+	return true;
+}
+
+function rawWrapVerifyUserTokenPublisherV2(token_seed)
+{
+	var	resobj = {result: true, message: null};
+
+	if(!rawVerifyUserTokenPublisherV2(token_seed)){
+		resobj.result	= false;
+		resobj.message	= 'token_seed(not printable) is not safe entity.';
+		r3logger.elog(resobj.message);
+		return resobj;
+	}
+	return resobj;
+}
+
+function rawVerifyUserTokenV2(user, token, token_seed)
+{
+	var	resobj = {result: true, message: null};
+
+	if(!apiutil.isSafeStrings(user, token, token_seed)){
+		resobj.result	= false;
+		resobj.message	= 'some parameters are wrong : token=' + JSON.stringify(token) + ', token_seed=<not printable>, user=' + JSON.stringify(user);
+		r3logger.elog(resobj.message);
+		return resobj;
+	}
+	// check seed
+	if(!rawVerifyUserTokenPublisherV2(token_seed)){
+		resobj.result	= false;
+		resobj.message	= 'token_seed(not printable) is not safe entity.';
+		r3logger.elog(resobj.message);
+		return resobj;
+	}
+	return resobj;
 }
 
 //
@@ -500,7 +578,7 @@ function rawGetUserScopedTokenV2(unscopedtoken, tenant, callback)
 // 
 function rawGetUserTenantListV2(unscopedtoken, callback)
 {
-	if(!apiutil.isSafeStrings(unscopedtoken)){
+	if(!apiutil.isSafeString(unscopedtoken)){
 		var	error = new Error('parameter is wrong : unscopedtoken=' + JSON.stringify(unscopedtoken));
 		r3logger.elog(error.message);
 		callback(error, null);
@@ -642,17 +720,21 @@ exports.getUserScopedToken = function(unscopedtoken, tenantname, tenantid, callb
 };
 
 //
+// Verify seed publisher type
+//
+exports.verifyUserTokenPublisher = function(token_seed)
+{
+	return rawWrapVerifyUserTokenPublisherV2(token_seed);
+};
+
+//
 // Verify token
 //
-// [NOTE]
-// The token is created by openstack(keystone), then we do not need to verify.
-// And this function will not be called on token by keystone, because this case
-// does not have token seed data.
+// tenant is not used.
 //
 exports.verifyUserToken = function(user, tenant, token, token_seed)				// eslint-disable-line no-unused-vars
 {
-	r3logger.wlog('Why is this verify token function called...');
-	return true;
+	return rawVerifyUserTokenV2(user, token, token_seed);
 };
 
 //

--- a/lib/openstackapiv3.js
+++ b/lib/openstackapiv3.js
@@ -78,21 +78,25 @@ var r3logger	= require('../lib/dbglogging');
 //
 // callback(error, result):
 //				result = {
-//					user:	user name										(*3)
-//					userid:	user id											(*4)
-//					scoped:	false											(always false)
-//					token:	token string(id)								(*1)
-//					expire:	expire string									(*2)
-//					region:	region string									(region name for keystone endpoint)
+//					user:		user name									(*3)
+//					userid:		user id										(*4)
+//					scoped:		false										(always false)
+//					token:		token string(id)							(*1)
+//					expire:		expire string								(*2)
+//					region:		region string								(region name for keystone endpoint)
+//					token_seed:	seed										({publisher: 'OPENSTACKV3'})
 //				}
 //
 function rawGetUserUnscopedTokenV3(uname, passwd, callback)
 {
-	if(!apiutil.isSafeStrings(uname, passwd)){
-		var	error = new Error('some parameters are wrong : uname=' + JSON.stringify(uname) + ', passwd=<not printed>');
+	if(!apiutil.isSafeString(uname)){
+		var	error = new Error('some parameters are wrong : uname=' + JSON.stringify(uname));
 		r3logger.elog(error.message);
 		callback(error, null);
 		return;
+	}
+	if(!apiutil.isSafeString(passwd)){
+		passwd = null;
 	}
 	var	_uname		= uname;
 	var	_passwd		= passwd;
@@ -204,14 +208,18 @@ function rawGetUserUnscopedTokenV3(uname, passwd, callback)
 					return;
 				}
 
+				// convert openstack user id(16 bytes hex string) to UUID(not UUID4)
+				var	user_id_uuid4	= apiutil.cvtNumberStringToUuid4(res_body.token.user.id, 16);
+
 				// build result
-				var	resobj		= {};
-				resobj.user		= res_body.token.user.name.toLowerCase();
-				resobj.userid	= res_body.token.user.id.toLowerCase();
-				resobj.scoped	= false;
-				resobj.token	= headers['x-subject-token'];
-				resobj.expire	= res_body.token.expires_at;
-				resobj.region	= keystone_ep.region.toLowerCase();
+				var	resobj			= {};
+				resobj.user			= res_body.token.user.name.toLowerCase();
+				resobj.userid		= user_id_uuid4;
+				resobj.scoped		= false;
+				resobj.token		= headers['x-subject-token'];
+				resobj.expire		= res_body.token.expires_at;
+				resobj.region		= keystone_ep.region.toLowerCase();
+				resobj.token_seed	= JSON.stringify({ publisher: 'OPENSTACKV3' });
 				_callback(null, resobj);
 			});
 		});
@@ -310,12 +318,13 @@ function rawGetUserUnscopedTokenV3(uname, passwd, callback)
 //
 // callback(error, result):
 //				result = {
-//					user:	user name										(*3)
-//					userid:	user id											(*4)
-//					scoped:	true											(always true)
-//					token:	token string(id)								(*1)
-//					expire:	expire string									(*2)
-//					region:	region string									(identity's *5 for region name)
+//					user:		user name									(*3)
+//					userid:		user id										(*4)
+//					scoped:		true										(always true)
+//					token:		token string(id)							(*1)
+//					expire:		expire string								(*2)
+//					region:		region string								(identity's *5 for region name)
+//					token_seed:	seed										({publisher: 'OPENSTACKV3'})
 //				}
 //
 function rawGetUserScopedTokenV3(unscopedtoken, tenantid, callback)
@@ -496,14 +505,18 @@ function rawGetUserScopedTokenV3(unscopedtoken, tenantid, callback)
 					return;
 				}
 
+				// convert openstack user id(16 bytes hex string) to UUID(not UUID4)
+				var	user_id_uuid4	= apiutil.cvtNumberStringToUuid4(res_body.token.user.id, 16);
+
 				// build result
-				var	resobj		= {};
-				resobj.user		= res_body.token.user.name.toLowerCase();
-				resobj.userid	= res_body.token.user.id.toLowerCase();
-				resobj.scoped	= true;
-				resobj.token	= headers['x-subject-token'];
-				resobj.expire	= res_body.token.expires_at;
-				resobj.region	= region.toLowerCase();
+				var	resobj			= {};
+				resobj.user			= res_body.token.user.name.toLowerCase();
+				resobj.userid		= user_id_uuid4;
+				resobj.scoped		= true;
+				resobj.token		= headers['x-subject-token'];
+				resobj.expire		= res_body.token.expires_at;
+				resobj.region		= region.toLowerCase();
+				resobj.token_seed	= JSON.stringify({ publisher: 'OPENSTACKV3' });
 				_callback(null, resobj);
 			});
 		});
@@ -517,6 +530,71 @@ function rawGetUserScopedTokenV3(unscopedtoken, tenantid, callback)
 		req.write(strbody);
 		req.end();
 	}, true);
+}
+
+//
+// Verify User Token for OpenStack V3
+//
+// user				:	target user name for token
+// token			:	check token
+// token_seed		:	token seed data
+//
+// result			:	{
+//							result:		true/false
+//							message:	null or error message string
+// 						}
+// 
+function rawVerifyUserTokenPublisherV3(token_seed)
+{
+	if(!apiutil.isSafeString(token_seed)){
+		return false;
+	}
+
+	// parse seed
+	var	seed = token_seed;
+	if(apiutil.checkSimpleJSON(token_seed)){
+		seed = JSON.parse(token_seed);
+	}
+	if(	!apiutil.isSafeEntity(seed)				||
+		!apiutil.isSafeString(seed.publisher)	||
+		(seed.publisher != 'OPENSTACKV3')		)		// publisher must be 'OPENSTACKV3'
+	{
+		return false;
+	}
+	return true;
+}
+
+function rawWrapVerifyUserTokenPublisherV3(token_seed)
+{
+	var	resobj = {result: true, message: null};
+
+	if(!rawVerifyUserTokenPublisherV3(token_seed)){
+		resobj.result	= false;
+		resobj.message	= 'token_seed(not printable) is not safe entity.';
+		r3logger.elog(resobj.message);
+		return resobj;
+	}
+	return resobj;
+}
+
+function rawVerifyUserTokenV3(user, token, token_seed)
+{
+	var	resobj = {result: true, message: null};
+
+	if(!apiutil.isSafeStrings(user, token, token_seed)){
+		resobj.result	= false;
+		resobj.message	= 'some parameters are wrong : token=' + JSON.stringify(token) + ', token_seed=<not printable>, user=' + JSON.stringify(user);
+		r3logger.elog(resobj.message);
+		return resobj;
+	}
+	// check seed
+	if(!rawVerifyUserTokenPublisherV3(token_seed)){
+		resobj.result	= false;
+		resobj.message	= 'token_seed(not printable) is not safe entity.';
+		r3logger.elog(resobj.message);
+		return resobj;
+	}
+	return resobj;
 }
 
 //
@@ -567,15 +645,25 @@ function rawGetUserScopedTokenV3(unscopedtoken, tenantid, callback)
 // 
 function rawGetUserTenantListV3(unscopedtoken, userid, callback)
 {
+	var	error;
 	if(!apiutil.isSafeStrings(unscopedtoken, userid)){
-		var	error = new Error('parameter is wrong : unscopedtoken=' + JSON.stringify(unscopedtoken) + ', userid=' + JSON.stringify(userid));
+		error = new Error('parameter is wrong : unscopedtoken=' + JSON.stringify(unscopedtoken) + ', userid=' + JSON.stringify(userid));
 		r3logger.elog(error.message);
 		callback(error, null);
 		return;
 	}
 	var	_unscopedtoken	= unscopedtoken;
-	var	_userid			= userid;
 	var	_callback		= callback;
+
+	// convert user id(UUID) to openstack user id(16 bytes hex string)
+	var	_bin_userid	= apiutil.cvtStrToBinUuid4(userid);
+	if(null == _bin_userid){
+		error		= new Error('parameter is wrong : userid=' + JSON.stringify(userid));
+		r3logger.elog(error.message);
+		callback(error, null);
+		return;
+	}
+	var	_userid		= _bin_userid.toString('hex');
 
 	// get end points for keystone
 	osksep.getKeystoneEndpoint(function(err, keystone_ep)
@@ -710,17 +798,21 @@ exports.getUserScopedToken = function(unscopedtoken, tenantname, tenantid, callb
 };
 
 //
+// Verify seed publisher type
+//
+exports.verifyUserTokenPublisher = function(token_seed)
+{
+	return rawWrapVerifyUserTokenPublisherV3(token_seed);
+};
+
+//
 // Verify token
 //
-// [NOTE]
-// The token is created by openstack(keystone), then we do not need to verify.
-// And this function will not be called on token by keystone, because this case
-// does not have token seed data.
+// tenant is not used.
 //
 exports.verifyUserToken = function(user, tenant, token, token_seed)				// eslint-disable-line no-unused-vars
 {
-	r3logger.wlog('Why is this verify token function called...');
-	return true;
+	return rawVerifyUserTokenV3(user, token, token_seed);
 };
 
 //

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "chai-http": "^4.2.1",
     "eslint": "^5.12.1",
     "mocha": "^5.2.0",
-    "nyc": "^13.1.0",
+    "nyc": "^14.1.1",
     "publish-please": "^5.4.3"
   },
   "scripts": {

--- a/routes/resource.js
+++ b/routes/resource.js
@@ -464,8 +464,10 @@ router.post('/', function(req, res, next)					// eslint-disable-line no-unused-v
 		}
 
 		// port
-		if(apiutil.isSafeString(req.body.resource.port)){
+		if(apiutil.isSafeString(req.body.resource.port) && !isNaN(req.body.resource.port)){
 			port = parseInt(req.body.resource.port);
+		}else{
+			port = 0;
 		}
 
 		// cuk
@@ -772,8 +774,10 @@ router.put('/', function(req, res, next)					// eslint-disable-line no-unused-va
 		}
 
 		// port
-		if(apiutil.isSafeString(req.query.port)){
+		if(apiutil.isSafeString(req.query.port) && !isNaN(req.query.port)){
 			port = parseInt(req.query.port);
+		}else{
+			port = 0;
 		}
 
 		// cuk
@@ -1035,8 +1039,10 @@ router.get('/', function(req, res, next)
 		}
 
 		// port
-		if(apiutil.isSafeString(req.query.port)){
+		if(apiutil.isSafeString(req.query.port) && !isNaN(req.query.port)){
 			port = parseInt(req.query.port);
+		}else{
+			port = 0;
 		}
 
 		// cuk
@@ -1213,8 +1219,10 @@ router.head('/', function(req, res, next)
 		}
 
 		// port
-		if(apiutil.isSafeString(req.query.port)){
+		if(apiutil.isSafeString(req.query.port) && !isNaN(req.query.port)){
 			port = parseInt(req.query.port);
+		}else{
+			port = 0;
 		}
 
 		// cuk
@@ -1242,7 +1250,6 @@ router.head('/', function(req, res, next)
 		// However, the case is rare and should not be used.
 		//
 		result = k2hr3.checkResourceByIP(clientip, port, cuk, role_yrn, comparam.res_yrn, restype, reskeyname);
-
 	}else{
 		// broken token
 		r3logger.elog('HEAD request is failure by internal error(token data broken).');
@@ -1423,8 +1430,10 @@ router.delete('/', function(req, res, next)					// eslint-disable-line no-unused
 		}
 
 		// port
-		if(apiutil.isSafeString(req.query.port)){
+		if(apiutil.isSafeString(req.query.port) && !isNaN(req.query.port)){
 			port = parseInt(req.query.port);
+		}else{
+			port = 0;
 		}
 
 		// cuk

--- a/test/auto_list.js
+++ b/test/auto_list.js
@@ -216,7 +216,7 @@ describe('API : LIST', function(){						// eslint-disable-line no-undef
 				expect(res.body).to.be.an('object');
 				expect(res.body.result).to.be.a('boolean').to.be.true;
 				expect(res.body.message).to.be.null;
-				expect(res.body.children).to.have.lengthOf(5);
+				expect(res.body.children).to.have.lengthOf(6);
 				done();
 			});
 	});
@@ -248,7 +248,7 @@ describe('API : LIST', function(){						// eslint-disable-line no-undef
 				expect(res.body).to.be.an('object');
 				expect(res.body.result).to.be.a('boolean').to.be.true;
 				expect(res.body.message).to.be.null;
-				expect(res.body.children).to.have.lengthOf(5);
+				expect(res.body.children).to.have.lengthOf(6);
 				done();
 			});
 	});

--- a/test/auto_role.js
+++ b/test/auto_role.js
@@ -40,6 +40,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 	var	user_roletoken_tenant0_k2hr3_entest_obj_role_01	= '';
 	var	user_roletoken_tenant0_k2hr3_entest_obj_role_02	= '';
 	var	user_roletoken_tenant0_k2hr3_entest_obj_role_03	= '';
+	var	user_roletoken_tenant0_k2hr3_entest_obj_role_04	= '';
 	var	user_roletoken_tenant0_k2hr3_entest_str_role_01	= '';
 	var	user_roletoken_tenant0_k2hr3_entest_str_role_02	= '';
 	var	user_roletoken_tenant0_k2hr3_entest_str_role_03	= '';
@@ -48,11 +49,14 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 	var	ip_roletoken_tenant0_k2hr3_entest_obj_role_01	= '';
 	var	ip_roletoken_tenant0_k2hr3_entest_obj_role_02	= '';
 	var	ip_roletoken_tenant0_k2hr3_entest_obj_role_03	= '';
+	var	ip_roletoken_tenant0_k2hr3_entest_obj_role_04	= '';
 	var	ip_roletoken_tenant0_k2hr3_entest_str_role_01	= '';
 	var	ip_roletoken_tenant0_k2hr3_entest_str_role_02	= '';
 	var	ip_roletoken_tenant0_k2hr3_entest_str_role_03	= '';
 	var	ip_roletoken_tenant0_test_service_tenant		= '';
 	var	ip_roletoken_testservice_tenant0_acr_role		= '';
+	var	ip_roletoken_tenant0_auto_test_role				= '';
+	var	ip_roletoken_tenant0_k8s_test_role				= '';
 
 	var	user_roletoken_tenant0_autotest_post_dummy_role1= '';	// eslint-disable-line no-unused-vars
 	var	user_roletoken_tenant0_autotest_post_dummy_role3= '';	// eslint-disable-line no-unused-vars
@@ -608,7 +612,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						host:		'role3.auto.test.k2hr3.dummy.yahoo.co.jp',			// host:	role3.auto.test.k2hr3.dummy.yahoo.co.jp
 						port:		8000,												// port:	8000
 						cuk:		'cuk',												// cuk:		cuk
-						extra:		'extra'												// extra:	extra
+						extra:		'openstack-auto-v1'									// extra:	openstack-auto-v1(if cuk is string type, must be openstack-auto-v1)
 					},
 				],
 				clear_hostname:	false,
@@ -639,7 +643,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						expect(res.body.role.policies[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:policy:k2hr3_entest_obj_pol_03');
 						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(1);
 						expect(res.body.role.aliases[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:role:autotest_post_dummy_role2');
-						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp * ', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp 8000 ', 'role2.auto.test.k2hr3.dummy.yahoo.co.jp * ', 'role3.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk extra'], ips: []});
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp * ', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp 8000 ', 'role2.auto.test.k2hr3.dummy.yahoo.co.jp * ', 'role3.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk openstack-auto-v1'], ips: []});
 
 						done();
 					});
@@ -669,7 +673,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						host:		'role3.auto.test.k2hr3.dummy.yahoo.co.jp',			// host:	role3.auto.test.k2hr3.dummy.yahoo.co.jp
 						port:		9000,												// port:	9000 : 8000 + 9000
 						cuk:		'cuk',												// cuk:		cuk
-						extra:		'extra'												// extra:	extra
+						extra:		'openstack-auto-v1'									// extra:	openstack-auto-v1(if cuk is string type, must be openstack-auto-v1)
 					},
 				],
 				clear_hostname:	false,
@@ -700,7 +704,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						expect(res.body.role.policies[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:policy:k2hr3_entest_obj_pol_03');
 						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(1);
 						expect(res.body.role.aliases[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:role:autotest_post_dummy_role2');
-						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp * ', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp * ', 'role2.auto.test.k2hr3.dummy.yahoo.co.jp 8000 ', 'role3.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk extra', 'role3.auto.test.k2hr3.dummy.yahoo.co.jp 9000 cuk extra'], ips: []});
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp * ', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp * ', 'role2.auto.test.k2hr3.dummy.yahoo.co.jp 8000 ', 'role3.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk openstack-auto-v1', 'role3.auto.test.k2hr3.dummy.yahoo.co.jp 9000 cuk openstack-auto-v1'], ips: []});
 
 						done();
 					});
@@ -824,7 +828,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						host:		'127.0.0.4',										// host:	127.0.0.4
 						port:		8000,												// port:	8000
 						cuk:		'cuk',												// cuk:		cuk
-						extra:		'extra'												// extra:	extra
+						extra:		'openstack-auto-v1'									// extra:	openstack-auto-v1(if cuk is string type, must be openstack-auto-v1)
 					},
 				],
 				clear_hostname:	false,
@@ -855,7 +859,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						expect(res.body.role.policies[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:policy:k2hr3_entest_obj_pol_03');
 						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(1);
 						expect(res.body.role.aliases[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:role:autotest_post_dummy_role2');
-						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role0.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: ['127.0.0.1 * ', '127.0.0.2 8000 ', '127.0.0.3 * ', '127.0.0.4 8000 cuk extra']});
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role0.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: ['127.0.0.1 * ', '127.0.0.2 8000 ', '127.0.0.3 * ', '127.0.0.4 8000 cuk openstack-auto-v1']});
 
 						done();
 					});
@@ -873,19 +877,19 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						host:		'127.0.0.2',										// host:	127.0.0.2
 						port:		0,													// port:	0(any) : 8000 -> 0
 						cuk:		'cuk',												// cuk:		cuk
-						extra:		'extra'												// extra:	extra
+						extra:		'openstack-auto-v1'									// extra:	openstack-auto-v1(if cuk is string type, must be openstack-auto-v1)
 					},
 					{
 						host:		'127.0.0.3',										// host:	127.0.0.3
 						port:		8000,												// port:	8000 : 0 <- 8000
 						cuk:		'cuk',												// cuk:		cuk
-						extra:		'extra'												// extra:	extra
+						extra:		'openstack-auto-v1'									// extra:	openstack-auto-v1(if cuk is string type, must be openstack-auto-v1)
 					},
 					{
 						host:		'127.0.0.4',										// host:	127.0.0.4
 						port:		9000,												// port:	9000 : 8000 + 9000
 						cuk:		'cuk',												// cuk:		cuk
-						extra:		'extra'												// extra:	extra
+						extra:		'openstack-auto-v1'									// extra:	openstack-auto-v1(if cuk is string type, must be openstack-auto-v1)
 					},
 				],
 				clear_hostname:	false,
@@ -916,7 +920,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						expect(res.body.role.policies[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:policy:k2hr3_entest_obj_pol_03');
 						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(1);
 						expect(res.body.role.aliases[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:role:autotest_post_dummy_role2');
-						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role0.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: ['127.0.0.1 * ', '127.0.0.2 * cuk extra', '127.0.0.3 8000 cuk extra', '127.0.0.4 8000 cuk extra', '127.0.0.4 9000 cuk extra']});
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role0.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: ['127.0.0.1 * ', '127.0.0.2 * cuk openstack-auto-v1', '127.0.0.3 8000 cuk openstack-auto-v1', '127.0.0.4 8000 cuk openstack-auto-v1', '127.0.0.4 9000 cuk openstack-auto-v1']});
 
 						done();
 					});
@@ -1031,7 +1035,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 				host: {
 					port:		8000,													// port:	8000 : 0 -> 8000
 					cuk:		'cuk',													// cuk:		cuk
-					extra:		'extra'													// extra:	extra
+					extra:		'openstack-auto-v1'										// extra:	openstack-auto-v1(if cuk is string type, must be openstack-auto-v1)
 				}
 			})
 			.end(function(err, res){
@@ -1064,7 +1068,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						expect(res.body.role.hosts.hostnames[0]).to.be.a('string').to.equal('host01.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp * ');
 						expect(res.body.role.hosts.hostnames[1]).to.be.a('string').to.equal('host02.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp * ');
 						expect(res.body.role.hosts.ips).to.be.an.instanceof(Array).to.have.lengthOf(4);
-						expect(res.body.role.hosts.ips[0]).to.be.a('string').to.equal('127.0.0.1 8000 cuk extra');
+						expect(res.body.role.hosts.ips[0]).to.be.a('string').to.equal('127.0.0.1 8000 cuk openstack-auto-v1');
 						expect(res.body.role.hosts.ips[1]).to.be.a('string').to.equal('127.1.2.0 * ');
 						expect(res.body.role.hosts.ips[2]).to.be.a('string').to.equal('127.1.2.1 * ');
 						expect(res.body.role.hosts.ips[3]).to.be.a('string').to.equal('127.10.10.10 * ');
@@ -1546,7 +1550,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 		uri		+= '?host=role1.auto.test.k2hr3.dummy.yahoo.co.jp';						// host:	role1.auto.test.k2hr3.dummy.yahoo.co.jp
 		uri		+= '&port=8000';														// port:	8000
 		uri		+= '&cuk=cuk';															// cuk:		cuk
-		uri		+= '&extra=' + JSON.stringify('extra');									// extra:	extra
+		uri		+= '&extra=' + JSON.stringify('openstack-auto-v1');						// extra:	openstack-auto-v1(if cuk is string type, must be openstack-auto-v1)
 
 		chai.request(app)
 			.put(uri)
@@ -1577,7 +1581,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						expect(res.body.role.policies[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:policy:k2hr3_entest_obj_pol_03');
 						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(1);
 						expect(res.body.role.aliases[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:role:autotest_put_dummy_role2');
-						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp * ', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk extra'], ips: []});
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp * ', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk openstack-auto-v1'], ips: []});
 
 						done();
 					});
@@ -1634,7 +1638,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 		uri		+= '?host=role.auto.test.k2hr3.dummy.yahoo.co.jp';						// host:	role.auto.test.k2hr3.dummy.yahoo.co.jp
 		uri		+= '&port=8000';														// port:	8000 : 0 -> 8000
 		uri		+= '&cuk=cuk';															// cuk:		cuk
-		uri		+= '&extra=' + JSON.stringify('extra');									// extra:	extra
+		uri		+= '&extra=' + JSON.stringify('openstack-auto-v1');						// extra:	openstack-auto-v1(if cuk is string type, must be openstack-auto-v1)
 
 		chai.request(app)
 			.put(uri)
@@ -1665,7 +1669,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						expect(res.body.role.policies[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:policy:k2hr3_entest_obj_pol_03');
 						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(1);
 						expect(res.body.role.aliases[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:role:autotest_put_dummy_role2');
-						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk extra', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: []});
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk openstack-auto-v1', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: []});
 
 						done();
 					});
@@ -1709,7 +1713,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						expect(res.body.role.policies[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:policy:k2hr3_entest_obj_pol_03');
 						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(1);
 						expect(res.body.role.aliases[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:role:autotest_put_dummy_role2');
-						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk extra', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: ['127.0.0.1 * ']});
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk openstack-auto-v1', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: ['127.0.0.1 * ']});
 
 						done();
 					});
@@ -1722,7 +1726,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 		uri		+= '?host=127.0.0.2';													// ip:		127.0.0.2
 		uri		+= '&port=8000';														// port:	8000
 		uri		+= '&cuk=cuk';															// cuk:		cuk
-		uri		+= '&extra=' + JSON.stringify('extra');									// extra:	extra
+		uri		+= '&extra=' + JSON.stringify('openstack-auto-v1');						// extra:	openstack-auto-v1(if cuk is string type, must be openstack-auto-v1)
 
 		chai.request(app)
 			.put(uri)
@@ -1753,7 +1757,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						expect(res.body.role.policies[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:policy:k2hr3_entest_obj_pol_03');
 						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(1);
 						expect(res.body.role.aliases[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:role:autotest_put_dummy_role2');
-						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk extra', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: ['127.0.0.1 * ', '127.0.0.2 8000 cuk extra']});
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk openstack-auto-v1', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: ['127.0.0.1 * ', '127.0.0.2 8000 cuk openstack-auto-v1']});
 
 						done();
 					});
@@ -1797,7 +1801,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						expect(res.body.role.policies[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:policy:k2hr3_entest_obj_pol_03');
 						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(1);
 						expect(res.body.role.aliases[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:role:autotest_put_dummy_role2');
-						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk extra', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: ['127.0.0.1 * ', '127.0.0.2 * ']});
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk openstack-auto-v1', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: ['127.0.0.1 * ', '127.0.0.2 * ']});
 
 						done();
 					});
@@ -1810,7 +1814,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 		uri		+= '?host=127.0.0.1';													// ip:		127.0.0.1
 		uri		+= '&port=8000';														// port:	8000 : 0 -> 8000
 		uri		+= '&cuk=cuk';															// cuk:		cuk
-		uri		+= '&extra=' + JSON.stringify('extra');									// extra:	extra
+		uri		+= '&extra=' + JSON.stringify('openstack-auto-v1');						// extra:	openstack-auto-v1(if cuk is string type, must be openstack-auto-v1)
 
 		chai.request(app)
 			.put(uri)
@@ -1841,7 +1845,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						expect(res.body.role.policies[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:policy:k2hr3_entest_obj_pol_03');
 						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(1);
 						expect(res.body.role.aliases[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:role:autotest_put_dummy_role2');
-						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk extra', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: ['127.0.0.1 8000 cuk extra', '127.0.0.2 * ']});
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk openstack-auto-v1', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: ['127.0.0.1 8000 cuk openstack-auto-v1', '127.0.0.2 * ']});
 
 						done();
 					});
@@ -1854,7 +1858,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 		uri		+= '?host=127.0.0.1';													// ip:		127.0.0.1
 		uri		+= '&port=0';															// port:	0 : 8000 -> 0
 		uri		+= '&cuk=';																// cuk:		null
-		uri		+= '&extra=' + JSON.stringify('extra');									// extra:	extra
+		uri		+= '&extra=' + JSON.stringify('openstack-auto-v1');						// extra:	openstack-auto-v1(if cuk is string type, must be openstack-auto-v1)
 
 		chai.request(app)
 			.put(uri)
@@ -1885,7 +1889,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						expect(res.body.role.policies[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:policy:k2hr3_entest_obj_pol_03');
 						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(1);
 						expect(res.body.role.aliases[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:role:autotest_put_dummy_role2');
-						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk extra', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: ['127.0.0.1 *  extra', '127.0.0.2 * ']});
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk openstack-auto-v1', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: ['127.0.0.1 *  openstack-auto-v1', '127.0.0.2 * ']});
 
 						done();
 					});
@@ -1948,7 +1952,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 		uri		+= '/yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02';	// path:	yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02
 		uri		+= '?port=8000';																	// port:	8000 : 0 -> 8000
 		uri		+= '&cuk=cuk';																		// cuk:		cuk
-		uri		+= '&extra=' + JSON.stringify('extra');												// extra:	extra
+		uri		+= '&extra=' + JSON.stringify('openstack-auto-v1');									// extra:	openstack-auto-v1(if cuk is string type, must be openstack-auto-v1)
 
 		chai.request(app)
 			.put(uri)
@@ -1984,7 +1988,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						expect(res.body.role.hosts.hostnames[0]).to.be.a('string').to.equal('host01.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp * ');
 						expect(res.body.role.hosts.hostnames[1]).to.be.a('string').to.equal('host02.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp * ');
 						expect(res.body.role.hosts.ips).to.be.an.instanceof(Array).to.have.lengthOf(4);
-						expect(res.body.role.hosts.ips[0]).to.be.a('string').to.equal('127.0.0.1 8000 cuk extra');
+						expect(res.body.role.hosts.ips[0]).to.be.a('string').to.equal('127.0.0.1 8000 cuk openstack-auto-v1');
 						expect(res.body.role.hosts.ips[1]).to.be.a('string').to.equal('127.1.2.0 * ');
 						expect(res.body.role.hosts.ips[2]).to.be.a('string').to.equal('127.1.2.1 * ');
 						expect(res.body.role.hosts.ips[3]).to.be.a('string').to.equal('127.10.10.10 * ');
@@ -2153,7 +2157,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 				expect(res.body.role.hosts.hostnames[0]).to.be.a('string').to.equal('host01.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp * ');
 				expect(res.body.role.hosts.hostnames[1]).to.be.a('string').to.equal('host02.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp * ');
 				expect(res.body.role.hosts.ips).to.be.an.instanceof(Array).to.have.lengthOf(4);
-				expect(res.body.role.hosts.ips[0]).to.be.a('string').to.equal('127.0.0.1 8000 cuk extra');
+				expect(res.body.role.hosts.ips[0]).to.be.a('string').to.equal('127.0.0.1 8000 cuk openstack-auto-v1');
 				expect(res.body.role.hosts.ips[1]).to.be.a('string').to.equal('127.1.2.0 * ');
 				expect(res.body.role.hosts.ips[2]).to.be.a('string').to.equal('127.1.2.1 * ');
 				expect(res.body.role.hosts.ips[3]).to.be.a('string').to.equal('127.10.10.10 * ');
@@ -2608,6 +2612,54 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 			});
 	});
 
+	it('GET /v1/role/token : get role token(k2hr3_entest_obj_role_01) by scoped token and expire(3600) with status 200', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/k2hr3_entest_obj_role_01';											// path:	yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01
+		uri		+= '?expire=3600';														// expire:	3600 sec
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', alltokens.scopedtoken.tenant0)							// tenant0
+			.end(function(err, res){
+				expect(res).to.have.status(200);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+				expect(res.body.token).to.be.an('string').to.not.empty;
+				expect(res.body.registerpath).to.be.an('string').to.not.empty;
+
+				user_roletoken_tenant0_k2hr3_entest_obj_role_01 = res.body.token;
+
+				done();
+			});
+	});
+
+	it('GET /v1/role/token : get role token(k2hr3_entest_obj_role_01) by scoped token and no expire with status 200', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/k2hr3_entest_obj_role_01';											// path:	yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01
+		uri		+= '?expire=0';															// expire:	0(means no expired)
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', alltokens.scopedtoken.tenant0)							// tenant0
+			.end(function(err, res){
+				expect(res).to.have.status(200);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+				expect(res.body.token).to.be.an('string').to.not.empty;
+				expect(res.body.registerpath).to.be.an('string').to.not.empty;
+
+				user_roletoken_tenant0_k2hr3_entest_obj_role_01 = res.body.token;
+
+				done();
+			});
+	});
+
 	it('GET /v1/role/token : failure(invalid token) get role token(k2hr3_entest_obj_role_01) by scoped token with status 401', function(done){	// eslint-disable-line no-undef
 		var	uri	= '/v1/role/token';
 		uri		+= '/k2hr3_entest_obj_role_01';											// path:	yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01
@@ -2798,7 +2850,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 				expect(res).to.be.json;
 				expect(res.body).to.be.an('object');
 				expect(res.body.result).to.be.a('boolean').to.be.false;
-				expect(res.body.message).to.be.a('string').to.equal('Not found ip(127.0.0.1) with port(0) in tenant(tenant0) + role(not_exist_role)');
+				expect(res.body.message).to.be.a('string').to.equal('Not found ip(127.0.0.1) with port(0) and cuk(null) in tenant(tenant0) + role(not_exist_role)');
 
 				done();
 			});
@@ -2807,6 +2859,29 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 	it('GET /v1/role/token : get role token(k2hr3_entest_obj_role_01) by no token with status 200', function(done){	// eslint-disable-line no-undef
 		var	uri	= '/v1/role/token';
 		uri		+= '/yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01';				// path:	yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(200);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+				expect(res.body.token).to.be.an('string').to.not.empty;
+				expect(res.body.registerpath).to.be.an('string').to.not.empty;
+
+				ip_roletoken_tenant0_k2hr3_entest_obj_role_01 = res.body.token;
+
+				done();
+			});
+	});
+
+	it('GET /v1/role/token : get role token(k2hr3_entest_obj_role_01) by no token and expire(ineffective) with status 200', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01';				// path:	yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01
+		uri		+= '?expire=3600';														// expire:	3600 sec(this value is ignored)
 
 		chai.request(app)
 			.get(uri)
@@ -2900,9 +2975,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 				expect(res).to.be.json;
 				expect(res.body).to.be.an('object');
 				expect(res.body.result).to.be.a('boolean').to.be.false;
-				expect(res.body.message).to.be.an('string').to.equal('Not found ip(127.0.0.1) with port(0) in tenant(tenant0) + role(k2hr3_entest_str_role_01)');
-
-				ip_roletoken_tenant0_k2hr3_entest_str_role_01 = '';
+				expect(res.body.message).to.be.an('string').to.equal('Not found ip(127.0.0.1) with port(0) and cuk(null) in tenant(tenant0) + role(k2hr3_entest_str_role_01)');
 
 				done();
 			});
@@ -2920,7 +2993,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 				expect(res).to.be.json;
 				expect(res.body).to.be.an('object');
 				expect(res.body.result).to.be.a('boolean').to.be.false;
-				expect(res.body.message).to.be.an('string').to.equal('Not found ip(127.0.0.1) with port(0) in tenant(tenant0) + role(k2hr3_entest_str_role_01/k2hr3_entest_str_role_02)');
+				expect(res.body.message).to.be.an('string').to.equal('Not found ip(127.0.0.1) with port(0) and cuk(null) in tenant(tenant0) + role(k2hr3_entest_str_role_01/k2hr3_entest_str_role_02)');
 
 				ip_roletoken_tenant0_k2hr3_entest_str_role_02 = '';
 
@@ -2940,7 +3013,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 				expect(res).to.be.json;
 				expect(res.body).to.be.an('object');
 				expect(res.body.result).to.be.a('boolean').to.be.false;
-				expect(res.body.message).to.be.an('string').to.equal('Not found ip(127.0.0.1) with port(0) in tenant(tenant0) + role(k2hr3_entest_str_role_03)');
+				expect(res.body.message).to.be.an('string').to.equal('Not found ip(127.0.0.1) with port(0) and cuk(null) in tenant(tenant0) + role(k2hr3_entest_str_role_03)');
 
 				ip_roletoken_tenant0_k2hr3_entest_str_role_03 = '';
 
@@ -2960,7 +3033,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 				expect(res).to.be.json;
 				expect(res.body).to.be.an('object');
 				expect(res.body.result).to.be.a('boolean').to.be.false;
-				expect(res.body.message).to.be.an('string').to.equal('Not found ip(127.0.0.1) with port(0) in tenant(tenant0) + role(test_service_tenant)');
+				expect(res.body.message).to.be.an('string').to.equal('Not found ip(127.0.0.1) with port(0) and cuk(null) in tenant(tenant0) + role(test_service_tenant)');
 
 				ip_roletoken_tenant0_test_service_tenant = '';
 
@@ -3271,6 +3344,30 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 			});
 	});
 
+	it('GET /v1/role/token : get role token(k2hr3_entest_obj_role_01) by role token and expire(ineffective) with status 200', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/k2hr3_entest_obj_role_01';												// path:	yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01
+		uri		+= '?expire=3600';															// expire:	3600 sec(but this value is ignored)
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', 'R=' + ip_roletoken_tenant0_k2hr3_entest_obj_role_01)		// role token by ip
+			.end(function(err, res){
+				expect(res).to.have.status(200);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+				expect(res.body.token).to.be.an('string').to.not.empty;
+				expect(res.body.registerpath).to.be.an('string').to.not.empty;
+
+				ip_roletoken_tenant0_k2hr3_entest_obj_role_01 = res.body.token;
+
+				done();
+			});
+	});
+
 	it('GET /v1/role/token : get role token(full yrn k2hr3_entest_obj_role_01) by role token with status 200', function(done){	// eslint-disable-line no-undef
 		var	uri	= '/v1/role/token';
 		uri		+= '/yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01';					// path:	yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01
@@ -3454,6 +3551,357 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 			});
 	});
 
+	it('GET /v1/role/token : failure get role token(auto_test_role) by openstack ip and no yrn role name with status 400', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/auto_test_role';														// path:	yrn:yahoo:::tenant0:role:auto_test_role
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(400);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.false;
+				expect(res.body.message).to.be.an('string').to.equal('GET request role name which is not full yrn, and not token. role name must be full yrn, if token is not specified.');
+
+				done();
+			});
+	});
+
+	it('GET /v1/role/token : get role token(auto_test_role) by openstack ip with status 200', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/yrn:yahoo:::tenant0:role:auto_test_role';								// path:	yrn:yahoo:::tenant0:role:auto_test_role
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(200);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+				expect(res.body.token).to.be.an('string').to.not.empty;
+				expect(res.body.registerpath).to.be.an('string').to.not.empty;
+
+				ip_roletoken_tenant0_auto_test_role = res.body.token;
+
+				done();
+			});
+	});
+
+	it('GET /v1/role/token : get role token(auto_test_role) by openstack ip and cuk(ineffective) with status 200', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/yrn:yahoo:::tenant0:role:auto_test_role';								// path:	yrn:yahoo:::tenant0:role:auto_test_role
+		uri		+= '?cuk=auto-test-cuk';													// cuk:		auto-test-cuk(but this value is ignored)
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(200);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+				expect(res.body.token).to.be.an('string').to.not.empty;
+				expect(res.body.registerpath).to.be.an('string').to.not.empty;
+
+				ip_roletoken_tenant0_auto_test_role = res.body.token;
+
+				done();
+			});
+	});
+
+	it('GET /v1/role/token : failure get role token(k8s_test_role) by k8s ip and no cuk with status 404', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/yrn:yahoo:::tenant0:role:k8s_test_role';									// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(404);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.false;
+				expect(res.body.message).to.be.an('string').to.equal('Not found ip(127.0.0.1) with port(0) and cuk(null) in tenant(tenant0) + role(k8s_test_role)');
+
+				done();
+			});
+	});
+
+	it('GET /v1/role/token : failure get role token(k8s_test_role) by k8s ip and no yrn role path with status 400', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/k8s_test_role';															// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+		uri		+= '?cuk=eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ%3d%3d';
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(400);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.false;
+				expect(res.body.message).to.be.an('string').to.equal('GET request role name which is not full yrn, and not token. role name must be full yrn, if token is not specified.');
+
+				done();
+			});
+	});
+
+	it('GET /v1/role/token : get role token(k8s_test_role) by k8s ip and cuk with status 200', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/yrn:yahoo:::tenant0:role:k8s_test_role';									// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+		uri		+= '?cuk=eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ%3d%3d';
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(200);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+				expect(res.body.token).to.be.an('string').to.not.empty;
+				expect(res.body.registerpath).to.be.an('string').to.not.empty;
+
+				ip_roletoken_tenant0_k8s_test_role = res.body.token;
+
+				done();
+			});
+	});
+
+	//
+	// Run Test(GET TOKEN LIST - SUCCESS/FAILURE)
+	//
+	it('FOR ROLE TOKEN LIST: GET /v1/role/token : get role token(k2hr3_entest_obj_role_04) by scoped token with status 200', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/k2hr3_entest_obj_role_04';											// path:	yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_04
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', alltokens.scopedtoken.tenant0)							// tenant0
+			.end(function(err, res){
+				expect(res).to.have.status(200);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+				expect(res.body.token).to.be.an('string').to.not.empty;
+				expect(res.body.registerpath).to.be.an('string').to.not.empty;
+
+				user_roletoken_tenant0_k2hr3_entest_obj_role_04 = res.body.token;
+
+				done();
+			});
+	});
+
+	it('FOR ROLE TOKEN LIST: GET /v1/role/token : get role token(k2hr3_entest_obj_role_04) by no token with status 200', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_04';				// path:	yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_04
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(200);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+				expect(res.body.token).to.be.an('string').to.not.empty;
+				expect(res.body.registerpath).to.be.an('string').to.not.empty;
+
+				ip_roletoken_tenant0_k2hr3_entest_obj_role_04 = res.body.token;
+
+				done();
+			});
+	});
+
+	it('GET /v1/role/token/list : failure get role token list(no role) no expand by user token with status 404', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token/list';
+		uri		+= '?expand=false';																// expand:	false
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', alltokens.scopedtoken.tenant0)									// tenant0
+			.end(function(err, res){
+				expect(res).to.have.status(404);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.false;
+				expect(res.body.message).to.be.an('string').to.equal('could not get role id(yrn:yahoo:::tenant0:role:list/id) value, or it is wrong value(null).');
+
+				done();
+			});
+	});
+
+	it('GET /v1/role/token/list : failure get role token list(not_exist_role) no expand by user token with status 404', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token/list';
+		uri		+= '/not_exist_role';															// path:	yrn:yahoo:::tenant0:role:not_exist_role
+		uri		+= '?expand=false';																// expand:	false
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', alltokens.scopedtoken.tenant0)									// tenant0
+			.end(function(err, res){
+				expect(res).to.have.status(404);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.false;
+				expect(res.body.message).to.be.an('string').to.equal('role("yrn:yahoo:::tenant0:role:not_exist_role") does not exist');
+
+				done();
+			});
+	});
+
+	it('GET /v1/role/token/list : get role token list(k2hr3_entest_obj_role_04) no expand by user token with status 200', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token/list';
+		uri		+= '/k2hr3_entest_obj_role_04';													// path:	yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_04
+		uri		+= '?expand=false';																// expand:	false
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', alltokens.scopedtoken.tenant0)									// tenant0
+			.end(function(err, res){
+				expect(res).to.have.status(200);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+				expect(res.body.tokens).to.be.an.instanceof(Array).to.have.lengthOf(2);
+
+				// make existed token list with sort
+				var	token_list = [];
+				token_list.push(ip_roletoken_tenant0_k2hr3_entest_obj_role_04);
+				token_list.push(user_roletoken_tenant0_k2hr3_entest_obj_role_04);
+				token_list.sort();
+
+				// sort result
+				res.body.tokens.sort();
+
+				// compare
+				expect(res.body.tokens[0]).to.be.a('string').to.equal(token_list[0]);
+				expect(res.body.tokens[1]).to.be.a('string').to.equal(token_list[1]);
+
+				done();
+			});
+	});
+
+	it('GET /v1/role/token/list : get role token list(k2hr3_entest_obj_role_04) expand(default) by user token with status 200', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token/list';
+		uri		+= '/k2hr3_entest_obj_role_04';													// path:	yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_04
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', alltokens.scopedtoken.tenant0)									// tenant0
+			.end(function(err, res){
+				expect(res).to.have.status(200);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+				expect(res.body.tokens).to.be.an('object');
+
+				// make token keys list
+				var	token_result_keys = Object.keys(res.body.tokens).sort();
+
+				// make existed token list with sort
+				var	token_list = [];
+				token_list.push(ip_roletoken_tenant0_k2hr3_entest_obj_role_04);
+				token_list.push(user_roletoken_tenant0_k2hr3_entest_obj_role_04);
+				token_list.sort();
+
+				// compare keys
+				expect(token_result_keys[0]).to.be.a('string').to.equal(token_list[0]);
+				expect(token_result_keys[1]).to.be.a('string').to.equal(token_list[1]);
+
+				// compare each key elements
+				expect(res.body.tokens[user_roletoken_tenant0_k2hr3_entest_obj_role_04]).to.be.an('object');
+				expect(res.body.tokens[user_roletoken_tenant0_k2hr3_entest_obj_role_04].date).to.be.an('string').to.not.empty;
+				expect(res.body.tokens[user_roletoken_tenant0_k2hr3_entest_obj_role_04].expire).to.be.an('string').to.not.empty;
+				expect(res.body.tokens[user_roletoken_tenant0_k2hr3_entest_obj_role_04].user).to.be.an('string').to.equal('dummyuser');
+				expect(res.body.tokens[user_roletoken_tenant0_k2hr3_entest_obj_role_04].hostname).to.be.a('null');
+				expect(res.body.tokens[user_roletoken_tenant0_k2hr3_entest_obj_role_04].ip).to.be.a('null');
+				expect(res.body.tokens[user_roletoken_tenant0_k2hr3_entest_obj_role_04].port).to.equal(0);
+				expect(res.body.tokens[user_roletoken_tenant0_k2hr3_entest_obj_role_04].cuk).to.be.a('null');
+
+				expect(res.body.tokens[ip_roletoken_tenant0_k2hr3_entest_obj_role_04]).to.be.an('object');
+				expect(res.body.tokens[ip_roletoken_tenant0_k2hr3_entest_obj_role_04].date).to.be.an('string').to.not.empty;
+				expect(res.body.tokens[ip_roletoken_tenant0_k2hr3_entest_obj_role_04].expire).to.be.an('string').to.not.empty;
+				expect(res.body.tokens[ip_roletoken_tenant0_k2hr3_entest_obj_role_04].user).to.be.a('null');
+				expect(res.body.tokens[ip_roletoken_tenant0_k2hr3_entest_obj_role_04].hostname).to.be.a('null');
+				expect(res.body.tokens[ip_roletoken_tenant0_k2hr3_entest_obj_role_04].ip).to.be.an('string').to.equal('127.0.0.1');
+				expect(res.body.tokens[ip_roletoken_tenant0_k2hr3_entest_obj_role_04].port).to.equal(0);
+				expect(res.body.tokens[ip_roletoken_tenant0_k2hr3_entest_obj_role_04].cuk).to.be.a('null');
+
+				done();
+			});
+	});
+
+	it('GET /v1/role/token/list : get role token list(k2hr3_entest_obj_role_04) expand by user token with status 200', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token/list';
+		uri		+= '/k2hr3_entest_obj_role_04';													// path:	yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_04
+		uri		+= '?expand=true';																// expand:	false
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', alltokens.scopedtoken.tenant0)									// tenant0
+			.end(function(err, res){
+				expect(res).to.have.status(200);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+				expect(res.body.tokens).to.be.an('object');
+
+				// make token keys list
+				var	token_result_keys = Object.keys(res.body.tokens).sort();
+
+				// make existed token list with sort
+				var	token_list = [];
+				token_list.push(ip_roletoken_tenant0_k2hr3_entest_obj_role_04);
+				token_list.push(user_roletoken_tenant0_k2hr3_entest_obj_role_04);
+				token_list.sort();
+
+				// compare keys
+				expect(token_result_keys[0]).to.be.a('string').to.equal(token_list[0]);
+				expect(token_result_keys[1]).to.be.a('string').to.equal(token_list[1]);
+
+				// compare each key elements
+				expect(res.body.tokens[user_roletoken_tenant0_k2hr3_entest_obj_role_04]).to.be.an('object');
+				expect(res.body.tokens[user_roletoken_tenant0_k2hr3_entest_obj_role_04].date).to.be.an('string').to.not.empty;
+				expect(res.body.tokens[user_roletoken_tenant0_k2hr3_entest_obj_role_04].expire).to.be.an('string').to.not.empty;
+				expect(res.body.tokens[user_roletoken_tenant0_k2hr3_entest_obj_role_04].user).to.be.an('string').to.equal('dummyuser');
+				expect(res.body.tokens[user_roletoken_tenant0_k2hr3_entest_obj_role_04].hostname).to.be.a('null');
+				expect(res.body.tokens[user_roletoken_tenant0_k2hr3_entest_obj_role_04].ip).to.be.a('null');
+				expect(res.body.tokens[user_roletoken_tenant0_k2hr3_entest_obj_role_04].port).to.equal(0);
+				expect(res.body.tokens[user_roletoken_tenant0_k2hr3_entest_obj_role_04].cuk).to.be.a('null');
+				expect(res.body.tokens[user_roletoken_tenant0_k2hr3_entest_obj_role_04].registerpath).to.be.an('string').to.not.empty;
+
+				expect(res.body.tokens[ip_roletoken_tenant0_k2hr3_entest_obj_role_04]).to.be.an('object');
+				expect(res.body.tokens[ip_roletoken_tenant0_k2hr3_entest_obj_role_04].date).to.be.an('string').to.not.empty;
+				expect(res.body.tokens[ip_roletoken_tenant0_k2hr3_entest_obj_role_04].expire).to.be.an('string').to.not.empty;
+				expect(res.body.tokens[ip_roletoken_tenant0_k2hr3_entest_obj_role_04].user).to.be.a('null');
+				expect(res.body.tokens[ip_roletoken_tenant0_k2hr3_entest_obj_role_04].hostname).to.be.a('null');
+				expect(res.body.tokens[ip_roletoken_tenant0_k2hr3_entest_obj_role_04].ip).to.be.an('string').to.equal('127.0.0.1');
+				expect(res.body.tokens[ip_roletoken_tenant0_k2hr3_entest_obj_role_04].port).to.equal(0);
+				expect(res.body.tokens[ip_roletoken_tenant0_k2hr3_entest_obj_role_04].cuk).to.be.a('null');
+				expect(res.body.tokens[ip_roletoken_tenant0_k2hr3_entest_obj_role_04].registerpath).to.be.an('string').to.not.empty;
+
+				done();
+			});
+	});
+
 	//
 	// Run Test(HEAD - SUCCESS/FAILURE)
 	//
@@ -3586,6 +4034,213 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 			.set('content-type', 'application/json')
 			.end(function(err, res){
 				expect(res).to.have.status(400);
+
+				done();
+			});
+	});
+
+	it('HEAD /v1/role : check access to role(k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02) by no scoped token with status 204', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02';	// path:	yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02
+
+		chai.request(app)
+			.head(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(204);
+
+				done();
+			});
+	});
+
+	it('HEAD /v1/role : check access to role(k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02) by no scoped token and cuk(ineffective) with status 204', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02';	// path:	yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02
+		uri		+= '?cuk=cuk';																		// cuk:		cuk(ineffective)
+
+		chai.request(app)
+			.head(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(204);
+
+				done();
+			});
+	});
+
+	it('HEAD /v1/role : check access to role(k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02) by no scoped token and port(ineffective) with status 204', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02';	// path:	yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02
+		uri		+= '?port=8000';																	// port:	8000(ineffective)
+
+		chai.request(app)
+			.head(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(204);
+
+				done();
+			});
+	});
+
+	it('HEAD /v1/role : failure check access to role(auto_test_role) by no scoped token with status 400', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/auto_test_role';											// path:	yrn:yahoo:::tenant0:role:auto_test_role
+
+		chai.request(app)
+			.head(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(400);
+
+				done();
+			});
+	});
+
+	it('HEAD /v1/role : check access to role(auto_test_role) by no scoped token with status 204', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:auto_test_role';					// path:	yrn:yahoo:::tenant0:role:auto_test_role
+
+		chai.request(app)
+			.head(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(204);
+
+				done();
+			});
+	});
+
+	it('HEAD /v1/role : check access to role(auto_test_role) by no scoped token and cuk(ineffective) with status 204', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:auto_test_role';					// path:	yrn:yahoo:::tenant0:role:auto_test_role
+		uri		+= '?cuk=auto-test-cuk';										// cuk:		auto-test-cuk(ineffective)
+
+		chai.request(app)
+			.head(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(204);
+
+				done();
+			});
+	});
+
+	it('HEAD /v1/role : check access to role(auto_test_role) by no scoped token and port(ineffective) with status 204', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:auto_test_role';					// path:	yrn:yahoo:::tenant0:role:auto_test_role
+		uri		+= '?port=8000';												// port:	8000(ineffective)
+
+		chai.request(app)
+			.head(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(204);
+
+				done();
+			});
+	});
+
+	it('HEAD /v1/role : failure check access to role(k8s_test_role) by no scoped token with status 400', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/k8s_test_role';											// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+
+		chai.request(app)
+			.head(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(400);
+
+				done();
+			});
+	});
+
+	it('HEAD /v1/role : failure check access to role(k8s_test_role) by no scoped token with status 403', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:k8s_test_role';					// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+
+		chai.request(app)
+			.head(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(403);
+
+				done();
+			});
+	});
+
+	it('HEAD /v1/role : failure check access to role(k8s_test_role) by no scoped token port(ineffective) with status 403', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:k8s_test_role';					// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+		uri		+= '?port=8000';												// port:	8000(ineffective)
+
+		chai.request(app)
+			.head(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(403);
+
+				done();
+			});
+	});
+
+	it('HEAD /v1/role : failure check access to role(k8s_test_role) by no scoped token and wrong cuk with status 403', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:k8s_test_role';					// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+		uri		+= '?cuk=no-exist-cuk';											// cuk:		no-exist-cuk
+
+		chai.request(app)
+			.head(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(403);
+
+				done();
+			});
+	});
+
+	it('HEAD /v1/role : check access to role(k8s_test_role) by no scoped token and cuk and no port(any) with status 204', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:k8s_test_role';					// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+		uri		+= '?cuk=eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ%3d%3d';
+
+		chai.request(app)
+			.head(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(204);
+
+				done();
+			});
+	});
+
+	it('HEAD /v1/role : failure check access to role(k8s_test_role) by no scoped token and cuk and wrong port with status 403', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:k8s_test_role';					// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+		uri		+= '?cuk=eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ%3d%3d';
+		uri		+= '&port=8000';												// port:	8000
+
+		chai.request(app)
+			.head(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(403);
+
+				done();
+			});
+	});
+
+	it('HEAD /v1/role : check access to role(k8s_test_role) by no scoped token and cuk and port with status 204', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:k8s_test_role';					// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+		uri		+= '?cuk=eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ%3d%3d';
+		uri		+= '&port=0';													// port:	0(any)
+
+		chai.request(app)
+			.head(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(204);
 
 				done();
 			});
@@ -3891,40 +4546,195 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 			});
 	});
 
+	it('HEAD /v1/role : check access to role(auto_test_role) by ip role token with status 204', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:auto_test_role';								// path:	yrn:yahoo:::tenant0:role:auto_test_role
+
+		chai.request(app)
+			.head(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', 'R=' + ip_roletoken_tenant0_auto_test_role)				// role token by ip
+			.end(function(err, res){
+				expect(res).to.have.status(204);
+
+				done();
+			});
+	});
+
+	it('HEAD /v1/role : check access to role(k8s_test_role) by ip role token with status 204', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:k8s_test_role';								// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+
+		chai.request(app)
+			.head(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', 'R=' + ip_roletoken_tenant0_k8s_test_role)					// role token by ip
+			.end(function(err, res){
+				expect(res).to.have.status(204);
+
+				done();
+			});
+	});
+
+	//
+	// Run Test(DELETE ROLE TOKEN - SUCCESS/FAILURE)
+	//
+	it('DELETE /v1/role/token : failure delete ip role token without user token for role(auto_test_role) with status 400', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/' + ip_roletoken_tenant0_auto_test_role;								// token:	for auto_test_role
+
+		chai.request(app)
+			.delete(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(400);
+
+				done();
+			});
+	});
+
+	it('DELETE /v1/role/token : delete ip role token with user token for role(auto_test_role) with status 204', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/' + ip_roletoken_tenant0_auto_test_role;								// token:	for auto_test_role
+
+		chai.request(app)
+			.delete(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', alltokens.scopedtoken.tenant0)								// tenant0
+			.end(function(err, res){
+				expect(res).to.have.status(204);
+
+				//
+				// Check resource data(not expand) set by this case.
+				//
+				chai.request(app)
+					.head('/v1/role/auto_test_role')
+					.set('content-type', 'application/json')
+					.set('x-auth-token', 'R=' + ip_roletoken_tenant0_auto_test_role)		// role token by ip
+					.end(function(err, res){
+						expect(res).to.have.status(401);
+
+						done();
+					});
+			});
+	});
+
+	it('REMAKE ROLE TOKEN FOR TEST: GET /v1/role/token : get role token(auto_test_role) for following test by openstack ip with status 200', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/yrn:yahoo:::tenant0:role:auto_test_role';								// path:	yrn:yahoo:::tenant0:role:auto_test_role
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(200);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+				expect(res.body.token).to.be.an('string').to.not.empty;
+				expect(res.body.registerpath).to.be.an('string').to.not.empty;
+
+				ip_roletoken_tenant0_auto_test_role = res.body.token;
+
+				done();
+			});
+	});
+
+	it('DELETE /v1/role/token : failure delete ip role token without user token for role(k8s_test_role) with status 400', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/' + ip_roletoken_tenant0_k8s_test_role;								// token:	for k8s_test_role
+
+		chai.request(app)
+			.delete(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(400);
+
+				done();
+			});
+	});
+
+	it('DELETE /v1/role/token : delete ip role token with user token for role(k8s_test_role) with status 204', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/' + ip_roletoken_tenant0_k8s_test_role;								// token:	for k8s_test_role
+
+		chai.request(app)
+			.delete(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', alltokens.scopedtoken.tenant0)								// tenant0
+			.end(function(err, res){
+				expect(res).to.have.status(204);
+
+				//
+				// Check resource data(not expand) set by this case.
+				//
+				chai.request(app)
+					.head('/v1/role/k8s_test_role')
+					.set('content-type', 'application/json')
+					.set('x-auth-token', 'R=' + ip_roletoken_tenant0_k8s_test_role)		// role token by ip
+					.end(function(err, res){
+						expect(res).to.have.status(401);
+
+						done();
+					});
+			});
+	});
+
+	it('REMAKE ROLE TOKEN FOR TEST: GET /v1/role/token : get role token(k8s_test_role) by k8s ip and cuk with status 200', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role/token';
+		uri		+= '/yrn:yahoo:::tenant0:role:k8s_test_role';									// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+		uri		+= '?cuk=eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ%3d%3d';
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(200);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+				expect(res.body.token).to.be.an('string').to.not.empty;
+				expect(res.body.registerpath).to.be.an('string').to.not.empty;
+
+				ip_roletoken_tenant0_k8s_test_role = res.body.token;
+
+				done();
+			});
+	});
+
 	//
 	// Run Test(DELETE - SUCCESS/FAILURE)
 	//
 	it('GET ROLE TOKEN BY USER FOR DUMMIES : dummy roles(autotest_post_dummy_role1, autotest_post_dummy_role3, autotest_put_dummy_role1, autotest_put_dummy_role4) with status 201', function(done){	// eslint-disable-line no-undef
 		var	r3token	= require('../lib/k2hr3tokens');
-		var	apiutil	= require('../lib/k2hr3apiutil');
-
 		var	result;
 		var	expire	= 24 * 60 * 60;																	// expire is 24H
-		var	base_id	= apiutil.convertHexString128ToBin64(alltokens.scopedtoken.tenant0.slice(2));	// [NOTE] cut prefix 'U='
 
 		// Get user role token for yrn:yahoo:::tenant0:role:autotest_post_dummy_role1
-		result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', base_id, 'yrn:yahoo:::tenant0:role:autotest_post_dummy_role1', expire);
+		result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', 'yrn:yahoo:::tenant0:role:autotest_post_dummy_role1', expire);
 		expect(result).to.be.an('object');
 		expect(result.result).to.be.a('boolean').to.be.true;
 		expect(result.token).to.be.an('string').to.not.empty;
 		user_roletoken_tenant0_autotest_post_dummy_role1 = result.token;
 
 		// Get user role token for yrn:yahoo:::tenant0:role:autotest_post_dummy_role3
-		result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', base_id, 'yrn:yahoo:::tenant0:role:autotest_post_dummy_role3', expire);
+		result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', 'yrn:yahoo:::tenant0:role:autotest_post_dummy_role3', expire);
 		expect(result).to.be.an('object');
 		expect(result.result).to.be.a('boolean').to.be.true;
 		expect(result.token).to.be.an('string').to.not.empty;
 		user_roletoken_tenant0_autotest_post_dummy_role3 = result.token;
 
 		// Get user role token for yrn:yahoo:::tenant0:role:autotest_put_dummy_role1
-		result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', base_id, 'yrn:yahoo:::tenant0:role:autotest_put_dummy_role1', expire);
+		result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', 'yrn:yahoo:::tenant0:role:autotest_put_dummy_role1', expire);
 		expect(result).to.be.an('object');
 		expect(result.result).to.be.a('boolean').to.be.true;
 		expect(result.token).to.be.an('string').to.not.empty;
 		user_roletoken_tenant0_autotest_put_dummy_role1 = result.token;
 
 		// Get user role token for yrn:yahoo:::tenant0:role:autotest_put_dummy_role4
-		result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', base_id, 'yrn:yahoo:::tenant0:role:autotest_put_dummy_role4', expire);
+		result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', 'yrn:yahoo:::tenant0:role:autotest_put_dummy_role4', expire);
 		expect(result).to.be.an('object');
 		expect(result.result).to.be.a('boolean').to.be.true;
 		expect(result.token).to.be.an('string').to.not.empty;
@@ -4008,14 +4818,14 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						expect(res.body.role.policies[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:policy:k2hr3_entest_obj_pol_03');
 						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(1);
 						expect(res.body.role.aliases[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:role:autotest_put_dummy_role2');
-						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk extra', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: ['127.0.0.1 *  extra', '127.0.0.2 * ']});
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: ['role.auto.test.k2hr3.dummy.yahoo.co.jp 8000 cuk openstack-auto-v1', 'role1.auto.test.k2hr3.dummy.yahoo.co.jp * '], ips: ['127.0.0.1 *  openstack-auto-v1', '127.0.0.2 * ']});
 
 						done();
 					});
 			});
 	});
 
-	it('DELETE /v1/role : delete 127.0.0.1 with wrong port from role(k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02) by no token with status 204', function(done){	// eslint-disable-line no-undef
+	it('DELETE /v1/role : failure delete 127.0.0.1 with wrong port from role(k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02) by no token with status 403', function(done){	// eslint-disable-line no-undef
 		var	uri	= '/v1/role';
 		uri		+= '/yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02';	// path:	yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02
 		uri		+= '?port=9000';																	// port:	9000(not exist)
@@ -4024,38 +4834,9 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 			.delete(uri)
 			.set('content-type', 'application/json')
 			.end(function(err, res){
-				expect(res).to.have.status(204);
+				expect(res).to.have.status(403);
 
-				//
-				// Check resource data(not expand) set by this case.
-				//
-				chai.request(app)
-					.get('/v1/role/k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02?expand=false')
-					.set('content-type', 'application/json')
-					.set('x-auth-token', alltokens.scopedtoken.tenant0)						// tenant0
-					.end(function(err, res){
-						expect(res).to.have.status(200);
-						expect(res).to.be.json;
-						expect(res.body).to.be.an('object');
-						expect(res.body.result).to.be.a('boolean').to.be.true;
-						expect(res.body.message).to.be.a('null');
-						expect(res.body.role).to.be.an('object');
-						expect(res.body.role.policies).to.be.an.instanceof(Array).to.have.lengthOf(1);
-						expect(res.body.role.policies[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:policy:k2hr3_entest_obj_pol_02');
-						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(1);
-						expect(res.body.role.aliases[0]).to.be.a('string').to.equal('yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_03');
-						expect(res.body.role.hosts).to.be.an('object');
-						expect(res.body.role.hosts.hostnames).to.be.an.instanceof(Array).to.have.lengthOf(2);
-						expect(res.body.role.hosts.hostnames[0]).to.be.a('string').to.equal('host01.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp * ');
-						expect(res.body.role.hosts.hostnames[1]).to.be.a('string').to.equal('host02.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp * ');
-						expect(res.body.role.hosts.ips).to.be.an.instanceof(Array).to.have.lengthOf(4);
-						expect(res.body.role.hosts.ips[0]).to.be.a('string').to.equal('127.0.0.1 8000 cuk extra');
-						expect(res.body.role.hosts.ips[1]).to.be.a('string').to.equal('127.1.2.0 * ');
-						expect(res.body.role.hosts.ips[2]).to.be.a('string').to.equal('127.1.2.1 * ');
-						expect(res.body.role.hosts.ips[3]).to.be.a('string').to.equal('127.10.10.10 * ');
-
-						done();
-					});
+				done();
 			});
 	});
 
@@ -4149,7 +4930,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 				// Check resource data(not expand) set by this case.
 				//
 				chai.request(app)
-					.head('/v1/role//k2hr3_entest_obj_role_01')
+					.head('/v1/role/k2hr3_entest_obj_role_01')
 					.set('content-type', 'application/json')
 					.set('x-auth-token', 'R=' + user_roletoken_tenant0_k2hr3_entest_obj_role_01)	// role token by user
 					.end(function(err, res){
@@ -4175,7 +4956,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 				// Check resource data(not expand) set by this case.
 				//
 				chai.request(app)
-					.head('/v1/role//k2hr3_entest_obj_role_01')
+					.head('/v1/role/k2hr3_entest_obj_role_01')
 					.set('content-type', 'application/json')
 					.set('x-auth-token', 'R=' + ip_roletoken_tenant0_k2hr3_entest_obj_role_01)	// role token by ip
 					.end(function(err, res){
@@ -4260,7 +5041,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						expect(res.body.role.hosts.hostnames[0]).to.be.a('string').to.equal('host01.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp * ');
 						expect(res.body.role.hosts.hostnames[1]).to.be.a('string').to.equal('host02.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp * ');
 						expect(res.body.role.hosts.ips).to.be.an.instanceof(Array).to.have.lengthOf(4);
-						expect(res.body.role.hosts.ips[0]).to.be.a('string').to.equal('127.0.0.1 8000 cuk extra');
+						expect(res.body.role.hosts.ips[0]).to.be.a('string').to.equal('127.0.0.1 8000 cuk openstack-auto-v1');
 						expect(res.body.role.hosts.ips[1]).to.be.a('string').to.equal('127.1.2.0 * ');
 						expect(res.body.role.hosts.ips[2]).to.be.a('string').to.equal('127.1.2.1 * ');
 						expect(res.body.role.hosts.ips[3]).to.be.a('string').to.equal('127.10.10.10 * ');
@@ -4352,7 +5133,7 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						expect(res.body.role.hosts.hostnames).to.be.an.instanceof(Array).to.have.lengthOf(1);
 						expect(res.body.role.hosts.hostnames[0]).to.be.a('string').to.equal('role1.auto.test.k2hr3.dummy.yahoo.co.jp * ');
 						expect(res.body.role.hosts.ips).to.be.an.instanceof(Array).to.have.lengthOf(2);
-						expect(res.body.role.hosts.ips[0]).to.be.a('string').to.equal('127.0.0.1 *  extra');
+						expect(res.body.role.hosts.ips[0]).to.be.a('string').to.equal('127.0.0.1 *  openstack-auto-v1');
 						expect(res.body.role.hosts.ips[1]).to.be.a('string').to.equal('127.0.0.2 * ');
 
 						done();
@@ -4571,6 +5352,190 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 						expect(res.body.role.hosts).to.be.an('object');
 						expect(res.body.role.hosts.hostnames).to.be.an.instanceof(Array).to.have.lengthOf(0);
 						expect(res.body.role.hosts.ips).to.be.an.instanceof(Array).to.have.lengthOf(0);
+
+						done();
+					});
+			});
+	});
+
+	it('DELETE /v1/role : delete ip role token without cuk for role(auto_test_role) with status 204', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/auto_test_role';														// path:	yrn:yahoo:::tenant0:role:auto_test_role
+
+		chai.request(app)
+			.delete(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', 'R=' + ip_roletoken_tenant0_auto_test_role)				// role token by ip
+			.end(function(err, res){
+				expect(res).to.have.status(204);
+
+				//
+				// Check resource data(not expand) set by this case.
+				//
+				chai.request(app)
+					.head('/v1/role/auto_test_role')
+					.set('content-type', 'application/json')
+					.set('x-auth-token', 'R=' + ip_roletoken_tenant0_auto_test_role)		// role token by ip
+					.end(function(err, res){
+						expect(res).to.have.status(401);
+
+						done();
+					});
+			});
+	});
+
+	it('DELETE /v1/role : failure delete ip role token without cuk for role(k8s_test_role) with status 400', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/k8s_test_role';															// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+
+		chai.request(app)
+			.delete(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', 'R=' + ip_roletoken_tenant0_k8s_test_role)						// role token by ip
+			.end(function(err, res){
+				expect(res).to.have.status(400);
+
+				done();
+			});
+	});
+
+	it('DELETE /v1/role : failure delete ip role token with cuk and wrong port for role(k8s_test_role) with status 400', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/k8s_test_role';															// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+		uri		+= '?cuk=eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ%3d%3d';
+		uri		+= '&port=8000';																// port:	8000(wrong port)
+
+		chai.request(app)
+			.delete(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', 'R=' + ip_roletoken_tenant0_k8s_test_role)						// role token by ip
+			.end(function(err, res){
+				expect(res).to.have.status(400);
+
+				done();
+			});
+	});
+
+	it('DELETE /v1/role : delete ip role token with cuk and port(0) for role(k8s_test_role) with status 400', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/k8s_test_role';															// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+		uri		+= '?cuk=eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ%3d%3d';
+
+		chai.request(app)
+			.delete(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', 'R=' + ip_roletoken_tenant0_k8s_test_role)						// role token by ip
+			.end(function(err, res){
+				expect(res).to.have.status(204);
+
+				//
+				// Check resource data(not expand) set by this case.
+				//
+				chai.request(app)
+					.head('/v1/role/k2hr3_entest_obj_role_01')
+					.set('content-type', 'application/json')
+					.set('x-auth-token', 'R=' + ip_roletoken_tenant0_k8s_test_role)				// role token by ip
+					.end(function(err, res){
+						expect(res).to.have.status(401);
+
+						done();
+					});
+			});
+	});
+
+	it('DELETE /v1/role : failure delete 127.0.0.1 without cuk from role(k8s_test_role) by no token with status 403', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:k8s_test_role';								// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+
+		chai.request(app)
+			.delete(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(403);
+
+				done();
+			});
+	});
+
+	it('DELETE /v1/role : failure delete 127.0.0.1 with wrong port without cuk from role(k8s_test_role) by no token with status 403', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:k8s_test_role';								// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+		uri		+= '?port=8000';															// port:	8000(wrong port number)
+
+		chai.request(app)
+			.delete(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(403);
+
+				done();
+			});
+	});
+
+	it('DELETE /v1/role : failure delete 127.0.0.1 with wrong cuk from role(k8s_test_role) by no token with status 403', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:k8s_test_role';								// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+		uri		+= '?cuk=wrong-cuk';														// cuk:		wrong-cuk
+
+		chai.request(app)
+			.delete(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(403);
+
+				done();
+			});
+	});
+
+	it('DELETE /v1/role : failure delete 127.0.0.1 with wrong port and cuk from role(k8s_test_role) by no token with status 403', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:k8s_test_role';								// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+		uri		+= '?cuk=eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ%3d%3d';
+		uri		+= '&port=8000';															// port:	8000(wrong port number)
+
+		chai.request(app)
+			.delete(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(403);
+
+				done();
+			});
+	});
+
+	it('DELETE /v1/role : delete 127.0.0.1 with cuk without port(any) from role(k8s_test_role) by no token with status 204', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/yrn:yahoo:::tenant0:role:k8s_test_role';								// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+		uri		+= '?cuk=eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ%3d%3d';
+
+		chai.request(app)
+			.delete(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(204);
+
+				//
+				// Check resource data(not expand) set by this case.
+				//
+				chai.request(app)
+					.get('/v1/role/k8s_test_role?expand=false')
+					.set('content-type', 'application/json')
+					.set('x-auth-token', alltokens.scopedtoken.tenant0)						// tenant0
+					.end(function(err, res){
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body).to.be.an('object');
+						expect(res.body.result).to.be.a('boolean').to.be.true;
+						expect(res.body.message).to.be.a('null');
+						expect(res.body.role).to.be.an('object');
+						expect(res.body.role.policies).to.be.an.instanceof(Array).to.have.lengthOf(0);
+						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(0);
+						expect(res.body.role.hosts).to.be.an('object');
+						expect(res.body.role.hosts.hostnames).to.be.an.instanceof(Array).to.have.lengthOf(0);
+						expect(res.body.role.hosts.ips).to.be.an.instanceof(Array).to.have.lengthOf(3);
+						expect(res.body.role.hosts.ips[0]).to.be.a('string').to.equal('255.255.127.1 * eyJrOHNfY29udGFpbmVyX2lkIjoiMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEiLCJrOHNfazJocjNfcmFuZCI6ImFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjEiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMSIsIms4c19wb2RfaWQiOiJhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4xIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0xIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1');
+						expect(res.body.role.hosts.ips[1]).to.be.a('string').to.equal('255.255.127.2 * eyJrOHNfY29udGFpbmVyX2lkIjoiMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIiLCJrOHNfazJocjNfcmFuZCI6ImJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjIiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMiIsIms4c19wb2RfaWQiOiJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4yIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0yIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1');
+						expect(res.body.role.hosts.ips[2]).to.be.a('string').to.equal('255.255.127.3 * eyJrOHNfY29udGFpbmVyX2lkIjoiMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMiLCJrOHNfazJocjNfcmFuZCI6ImNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjMiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMyIsIms4c19wb2RfaWQiOiJjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYyIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4zIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0zIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1');
 
 						done();
 					});
@@ -4832,6 +5797,189 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 			});
 	});
 
+	it('PUT /v1/role : prepare - add 255.255.127.5 to target role(autotest_del_k8s_role) by scoped token with status 201', function(done){	// eslint-disable-line no-undef
+		//
+		// cuk =	"eyJrOHNfY29udGFpbmVyX2lkIjoiNTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTUiLCJrOHNfazJocjNfcmFuZCI6ImVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjUiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNSIsIms4c19wb2RfaWQiOiJlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy41IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC01IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9"
+		// 		=>	base64 {
+		// 				json {
+		// 					k8s_container_id:		"55555555555555555555555555555555",
+		// 					k8s_k2hr3_rand:			"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+		// 					k8s_namespace:			"auto-test-namespace",
+		// 					k8s_node_ip:			"255.255.127.5",
+		// 					k8s_node_name:			"auto-test-node-5",
+		// 					k8s_pod_id:				"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+		// 					k8s_pod_ip:				"255.127.127.5",
+		// 					k8s_pod_name:			"auto-test-pod-5",
+		// 					k8s_service_account:	"auto-test-sa"
+		// 				}
+		// 			}
+		//
+		var	uri	= '/v1/role';
+		uri		+= '/autotest_del_k8s_role';											// path:	yrn:yahoo:::tenant0:role:autotest_del_k8s_role
+		uri		+= '?host=255.255.127.5';												// host:	255.255.127.5(dummy)
+		uri		+= '&port=0';															// port:	0(any)
+		uri		+= '&cuk=eyJrOHNfY29udGFpbmVyX2lkIjoiNTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTUiLCJrOHNfazJocjNfcmFuZCI6ImVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjUiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNSIsIms4c19wb2RfaWQiOiJlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy41IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC01IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9';
+		uri		+= '&extra=k8s-auto-v1';												// extra:	k8s-auto-v1
+
+		chai.request(app)
+			.put(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', alltokens.scopedtoken.tenant0)							// tenant0
+			.end(function(err, res){
+				expect(res).to.have.status(201);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+
+				//
+				// Check role data(not expand) set by this case.
+				//
+				chai.request(app)
+					.get('/v1/role/autotest_del_k8s_role?expand=false')
+					.set('content-type', 'application/json')
+					.set('x-auth-token', alltokens.scopedtoken.tenant0)					// tenant0
+					.end(function(err, res){
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body).to.be.an('object');
+						expect(res.body.result).to.be.a('boolean').to.be.true;
+						expect(res.body.message).to.be.a('null');
+						expect(res.body.role).to.be.an('object');
+						expect(res.body.role.policies).to.be.an.instanceof(Array).to.have.lengthOf(0);
+						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(0);
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: [], ips: [
+							'255.255.127.5 * eyJrOHNfY29udGFpbmVyX2lkIjoiNTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTUiLCJrOHNfazJocjNfcmFuZCI6ImVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjUiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNSIsIms4c19wb2RfaWQiOiJlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy41IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC01IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1'
+						]});
+
+						done();
+					});
+			});
+	});
+
+	it('PUT /v1/role : prepare - add 255.255.127.6 to target role(autotest_del_k8s_role) by scoped token with status 201', function(done){	// eslint-disable-line no-undef
+		//
+		// cuk =	"eyJrOHNfY29udGFpbmVyX2lkIjoiNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYiLCJrOHNfazJocjNfcmFuZCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjYiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNiIsIms4c19wb2RfaWQiOiJmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy42IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC02IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9"
+		// 		=>	base64 {
+		// 				json {
+		// 					k8s_container_id:		"66666666666666666666666666666666",
+		// 					k8s_k2hr3_rand:			"ffffffffffffffffffffffffffffffff",
+		// 					k8s_namespace:			"auto-test-namespace",
+		// 					k8s_node_ip:			"255.255.127.6",
+		// 					k8s_node_name:			"auto-test-node-6",
+		// 					k8s_pod_id:				"ffffffffffffffffffffffffffffffff",
+		// 					k8s_pod_ip:				"255.127.127.6",
+		// 					k8s_pod_name:			"auto-test-pod-6",
+		// 					k8s_service_account:	"auto-test-sa"
+		// 				}
+		// 			}
+		//
+		var	uri	= '/v1/role';
+		uri		+= '/autotest_del_k8s_role';											// path:	yrn:yahoo:::tenant0:role:autotest_del_k8s_role
+		uri		+= '?host=255.255.127.6';												// host:	255.255.127.6(dummy)
+		uri		+= '&port=0';															// port:	0(any)
+		uri		+= '&cuk=eyJrOHNfY29udGFpbmVyX2lkIjoiNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYiLCJrOHNfazJocjNfcmFuZCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjYiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNiIsIms4c19wb2RfaWQiOiJmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy42IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC02IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9';
+		uri		+= '&extra=k8s-auto-v1';												// extra:	k8s-auto-v1
+
+		chai.request(app)
+			.put(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', alltokens.scopedtoken.tenant0)							// tenant0
+			.end(function(err, res){
+				expect(res).to.have.status(201);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+
+				//
+				// Check role data(not expand) set by this case.
+				//
+				chai.request(app)
+					.get('/v1/role/autotest_del_k8s_role?expand=false')
+					.set('content-type', 'application/json')
+					.set('x-auth-token', alltokens.scopedtoken.tenant0)					// tenant0
+					.end(function(err, res){
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body).to.be.an('object');
+						expect(res.body.result).to.be.a('boolean').to.be.true;
+						expect(res.body.message).to.be.a('null');
+						expect(res.body.role).to.be.an('object');
+						expect(res.body.role.policies).to.be.an.instanceof(Array).to.have.lengthOf(0);
+						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(0);
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: [], ips: [
+							'255.255.127.5 * eyJrOHNfY29udGFpbmVyX2lkIjoiNTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTUiLCJrOHNfazJocjNfcmFuZCI6ImVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjUiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNSIsIms4c19wb2RfaWQiOiJlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy41IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC01IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1',
+							'255.255.127.6 * eyJrOHNfY29udGFpbmVyX2lkIjoiNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYiLCJrOHNfazJocjNfcmFuZCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjYiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNiIsIms4c19wb2RfaWQiOiJmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy42IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC02IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1'
+						]});
+
+						done();
+					});
+			});
+	});
+
+	it('PUT /v1/role : prepare - add 255.255.127.7 to target role(autotest_del_k8s_role) by scoped token with status 201', function(done){	// eslint-disable-line no-undef
+		//
+		// cuk =	"eyJrOHNfY29udGFpbmVyX2lkIjoiNzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3NzciLCJrOHNfazJocjNfcmFuZCI6ImZmZmZmZmZmZmZmZmZmZmZlZWVlZWVlZWVlZWVlZWVlIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjciLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNyIsIms4c19wb2RfaWQiOiJmZmZmZmZmZmZmZmZmZmZmZWVlZWVlZWVlZWVlZWVlZSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy43IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC03IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9"
+		// 		=>	base64 {
+		// 				json {
+		// 					k8s_container_id:		"77777777777777777777777777777777",
+		// 					k8s_k2hr3_rand:			"ffffffffffffffffeeeeeeeeeeeeeeee",
+		// 					k8s_namespace:			"auto-test-namespace",
+		// 					k8s_node_ip:			"255.255.127.7",
+		// 					k8s_node_name:			"auto-test-node-7",
+		// 					k8s_pod_id:				"ffffffffffffffffeeeeeeeeeeeeeeee",
+		// 					k8s_pod_ip:				"255.127.127.7",
+		// 					k8s_pod_name:			"auto-test-pod-7",
+		// 					k8s_service_account:	"auto-test-sa"
+		// 				}
+		// 			}
+		//
+		var	uri	= '/v1/role';
+		uri		+= '/autotest_del_k8s_role';											// path:	yrn:yahoo:::tenant0:role:autotest_del_k8s_role
+		uri		+= '?host=255.255.127.7';												// host:	255.255.127.7(dummy)
+		uri		+= '&port=0';															// port:	0(any)
+		uri		+= '&cuk=eyJrOHNfY29udGFpbmVyX2lkIjoiNzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3NzciLCJrOHNfazJocjNfcmFuZCI6ImZmZmZmZmZmZmZmZmZmZmZlZWVlZWVlZWVlZWVlZWVlIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjciLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNyIsIms4c19wb2RfaWQiOiJmZmZmZmZmZmZmZmZmZmZmZWVlZWVlZWVlZWVlZWVlZSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy43IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC03IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9';
+		uri		+= '&extra=k8s-auto-v1';												// extra:	k8s-auto-v1
+
+		chai.request(app)
+			.put(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', alltokens.scopedtoken.tenant0)							// tenant0
+			.end(function(err, res){
+				expect(res).to.have.status(201);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+
+				//
+				// Check role data(not expand) set by this case.
+				//
+				chai.request(app)
+					.get('/v1/role/autotest_del_k8s_role?expand=false')
+					.set('content-type', 'application/json')
+					.set('x-auth-token', alltokens.scopedtoken.tenant0)					// tenant0
+					.end(function(err, res){
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body).to.be.an('object');
+						expect(res.body.result).to.be.a('boolean').to.be.true;
+						expect(res.body.message).to.be.a('null');
+						expect(res.body.role).to.be.an('object');
+						expect(res.body.role.policies).to.be.an.instanceof(Array).to.have.lengthOf(0);
+						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(0);
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: [], ips: [
+							'255.255.127.5 * eyJrOHNfY29udGFpbmVyX2lkIjoiNTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTUiLCJrOHNfazJocjNfcmFuZCI6ImVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjUiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNSIsIms4c19wb2RfaWQiOiJlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy41IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC01IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1',
+							'255.255.127.6 * eyJrOHNfY29udGFpbmVyX2lkIjoiNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYiLCJrOHNfazJocjNfcmFuZCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjYiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNiIsIms4c19wb2RfaWQiOiJmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy42IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC02IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1',
+							'255.255.127.7 * eyJrOHNfY29udGFpbmVyX2lkIjoiNzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3NzciLCJrOHNfazJocjNfcmFuZCI6ImZmZmZmZmZmZmZmZmZmZmZlZWVlZWVlZWVlZWVlZWVlIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjciLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNyIsIms4c19wb2RfaWQiOiJmZmZmZmZmZmZmZmZmZmZmZWVlZWVlZWVlZWVlZWVlZSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy43IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC03IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1'
+						]});
+
+						done();
+					});
+			});
+	});
+
 	//
 	// Run Test(CUK IP - DELETE - SUCCESS/FAILURE)
 	//
@@ -4839,7 +5987,6 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 		var	uri	= '/v1/role';
 		uri		+= '?host=192.168.0.1';													// host:	192.168.0.1(dummy)
 		uri		+= '&cuk=test-auto-cuk';												// cuk:		test-auto-cuk
-		uri		+= '&extra=openstack-auto-v1';											// extra:	openstack-auto-v1
 
 		chai.request(app)
 			.delete(uri)
@@ -4873,7 +6020,6 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 	it('DELETE /v1/role : delete all ip addresses by cuk from target role(autotest_del_target_role) by scoped token with status 201', function(done){	// eslint-disable-line no-undef
 		var	uri	= '/v1/role';
 		uri		+= '?cuk=test-auto-cuk';												// cuk:		test-auto-cuk
-		uri		+= '&extra=openstack-auto-v1';											// extra:	openstack-auto-v1
 
 		chai.request(app)
 			.delete(uri)
@@ -4886,6 +6032,111 @@ describe('API : ROLE', function(){						// eslint-disable-line no-undef
 				//
 				chai.request(app)
 					.get('/v1/role/autotest_del_target_role?expand=false')
+					.set('content-type', 'application/json')
+					.set('x-auth-token', alltokens.scopedtoken.tenant0)					// tenant0
+					.end(function(err, res){
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body).to.be.an('object');
+						expect(res.body.result).to.be.a('boolean').to.be.true;
+						expect(res.body.message).to.be.a('null');
+						expect(res.body.role).to.be.an('object');
+						expect(res.body.role.policies).to.be.an.instanceof(Array).to.have.lengthOf(0);
+						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(0);
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: [], ips: []});
+
+						done();
+					});
+			});
+	});
+
+	it('DELETE /v1/role : delete only 255.255.127.5 by cuk from target role(autotest_del_k8s_role) by scoped token with status 201', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '?host=255.255.127.5';												// host:	255.255.127.5(dummy)
+		uri		+= '&cuk=eyJrOHNfY29udGFpbmVyX2lkIjoiNTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTUiLCJrOHNfazJocjNfcmFuZCI6ImVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjUiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNSIsIms4c19wb2RfaWQiOiJlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy41IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC01IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9';
+
+		chai.request(app)
+			.delete(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(204);
+
+				//
+				// Check role data(not expand) set by this case.
+				//
+				chai.request(app)
+					.get('/v1/role/autotest_del_k8s_role?expand=false')
+					.set('content-type', 'application/json')
+					.set('x-auth-token', alltokens.scopedtoken.tenant0)					// tenant0
+					.end(function(err, res){
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body).to.be.an('object');
+						expect(res.body.result).to.be.a('boolean').to.be.true;
+						expect(res.body.message).to.be.a('null');
+						expect(res.body.role).to.be.an('object');
+						expect(res.body.role.policies).to.be.an.instanceof(Array).to.have.lengthOf(0);
+						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(0);
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: [], ips: [
+							'255.255.127.6 * eyJrOHNfY29udGFpbmVyX2lkIjoiNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYiLCJrOHNfazJocjNfcmFuZCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjYiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNiIsIms4c19wb2RfaWQiOiJmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy42IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC02IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1',
+							'255.255.127.7 * eyJrOHNfY29udGFpbmVyX2lkIjoiNzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3NzciLCJrOHNfazJocjNfcmFuZCI6ImZmZmZmZmZmZmZmZmZmZmZlZWVlZWVlZWVlZWVlZWVlIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjciLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNyIsIms4c19wb2RfaWQiOiJmZmZmZmZmZmZmZmZmZmZmZWVlZWVlZWVlZWVlZWVlZSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy43IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC03IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1'
+						]});
+
+						done();
+					});
+			});
+	});
+
+	it('DELETE /v1/role : delete only 255.255.127.6 by cuk and no host from target role(autotest_del_k8s_role) by scoped token with status 201', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '?cuk=eyJrOHNfY29udGFpbmVyX2lkIjoiNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYiLCJrOHNfazJocjNfcmFuZCI6ImZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjYiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNiIsIms4c19wb2RfaWQiOiJmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy42IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC02IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9';
+
+		chai.request(app)
+			.delete(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(204);
+
+				//
+				// Check role data(not expand) set by this case.
+				//
+				chai.request(app)
+					.get('/v1/role/autotest_del_k8s_role?expand=false')
+					.set('content-type', 'application/json')
+					.set('x-auth-token', alltokens.scopedtoken.tenant0)					// tenant0
+					.end(function(err, res){
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body).to.be.an('object');
+						expect(res.body.result).to.be.a('boolean').to.be.true;
+						expect(res.body.message).to.be.a('null');
+						expect(res.body.role).to.be.an('object');
+						expect(res.body.role.policies).to.be.an.instanceof(Array).to.have.lengthOf(0);
+						expect(res.body.role.aliases).to.be.an.instanceof(Array).to.have.lengthOf(0);
+						expect(res.body.role.hosts).to.be.an('object').to.deep.equal({hostnames: [], ips: [
+							'255.255.127.7 * eyJrOHNfY29udGFpbmVyX2lkIjoiNzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3NzciLCJrOHNfazJocjNfcmFuZCI6ImZmZmZmZmZmZmZmZmZmZmZlZWVlZWVlZWVlZWVlZWVlIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjciLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNyIsIms4c19wb2RfaWQiOiJmZmZmZmZmZmZmZmZmZmZmZWVlZWVlZWVlZWVlZWVlZSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy43IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC03IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1'
+						]});
+
+						done();
+					});
+			});
+	});
+
+	it('DELETE /v1/role : delete only 255.255.127.7 by cuk and no host from target role(autotest_del_k8s_role) by scoped token with status 201', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '?cuk=eyJrOHNfY29udGFpbmVyX2lkIjoiNzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3NzciLCJrOHNfazJocjNfcmFuZCI6ImZmZmZmZmZmZmZmZmZmZmZlZWVlZWVlZWVlZWVlZWVlIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjciLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtNyIsIms4c19wb2RfaWQiOiJmZmZmZmZmZmZmZmZmZmZmZWVlZWVlZWVlZWVlZWVlZSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy43IiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC03IiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9';
+
+		chai.request(app)
+			.delete(uri)
+			.set('content-type', 'application/json')
+			.end(function(err, res){
+				expect(res).to.have.status(204);
+
+				//
+				// Check role data(not expand) set by this case.
+				//
+				chai.request(app)
+					.get('/v1/role/autotest_del_k8s_role?expand=false')
 					.set('content-type', 'application/json')
 					.set('x-auth-token', alltokens.scopedtoken.tenant0)					// tenant0
 					.end(function(err, res){

--- a/test/auto_token_util.js
+++ b/test/auto_token_util.js
@@ -106,7 +106,6 @@ exports.before = function(parentobj, alltoken, done)
 				done();
 				return;
 			}
-			var	unscopedtoken0			 = token;
 			alltoken.scopedtoken.tenant0 = 'U=' + token;
 
 			// Get scoped token for tenant1
@@ -118,15 +117,13 @@ exports.before = function(parentobj, alltoken, done)
 					done();
 					return;
 				}
-				var	unscopedtoken1			 = token;
 				alltoken.scopedtoken.tenant1 = 'U=' + token;
 
 				var	result;
 				var	expire	= 24 * 60 * 60;										// expire is 24H
-				var	base_id	= apiutil.convertHexString128ToBin64(unscopedtoken0);
 
 				// Get role token for yrn:yahoo:::tenant0:role:k2hr3_entest_str_role_01
-				result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', base_id, 'yrn:yahoo:::tenant0:role:k2hr3_entest_str_role_01', expire);
+				result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', 'yrn:yahoo:::tenant0:role:k2hr3_entest_str_role_01', expire);
 				if(!apiutil.isSafeEntity(result) || !apiutil.isSafeEntity(result.result) || false === result.result){
 					clearAllToken(_alltoken);
 					_parentobj.timeout(_buptimeout);
@@ -136,7 +133,7 @@ exports.before = function(parentobj, alltoken, done)
 				alltoken.roletoken.tenant0_k2hr3_entest_str_role_01 = 'R=' + result.token;
 
 				// Get role token for yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01
-				result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', base_id, 'yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01', expire);
+				result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', 'yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01', expire);
 				if(!apiutil.isSafeEntity(result) || !apiutil.isSafeEntity(result.result) || false === result.result){
 					clearAllToken(_alltoken);
 					_parentobj.timeout(_buptimeout);
@@ -146,7 +143,7 @@ exports.before = function(parentobj, alltoken, done)
 				alltoken.roletoken.tenant0_k2hr3_entest_obj_role_01 = 'R=' + result.token;
 
 				// Get role token for yrn:yahoo:::tenant0:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02
-				result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', base_id, 'yrn:yahoo:::tenant0:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02', expire);
+				result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', 'yrn:yahoo:::tenant0:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02', expire);
 				if(!apiutil.isSafeEntity(result) || !apiutil.isSafeEntity(result.result) || false === result.result){
 					clearAllToken(_alltoken);
 					_parentobj.timeout(_buptimeout);
@@ -156,7 +153,7 @@ exports.before = function(parentobj, alltoken, done)
 				alltoken.roletoken.tenant0_k2hr3_entest_str_role_02 = 'R=' + result.token;
 
 				// Get role token for yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02
-				result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', base_id, 'yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02', expire);
+				result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', 'yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02', expire);
 				if(!apiutil.isSafeEntity(result) || !apiutil.isSafeEntity(result.result) || false === result.result){
 					clearAllToken(_alltoken);
 					_parentobj.timeout(_buptimeout);
@@ -166,7 +163,7 @@ exports.before = function(parentobj, alltoken, done)
 				alltoken.roletoken.tenant0_k2hr3_entest_obj_role_02 = 'R=' + result.token;
 
 				// Get role token for yrn:yahoo:::tenant0:role:k2hr3_entest_str_role_03
-				result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', base_id, 'yrn:yahoo:::tenant0:role:k2hr3_entest_str_role_03', expire);
+				result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', 'yrn:yahoo:::tenant0:role:k2hr3_entest_str_role_03', expire);
 				if(!apiutil.isSafeEntity(result) || !apiutil.isSafeEntity(result.result) || false === result.result){
 					clearAllToken(_alltoken);
 					_parentobj.timeout(_buptimeout);
@@ -176,7 +173,7 @@ exports.before = function(parentobj, alltoken, done)
 				alltoken.roletoken.tenant0_k2hr3_entest_str_role_03 = 'R=' + result.token;
 
 				// Get role token for yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_03
-				result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', base_id, 'yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_03', expire);
+				result = r3token.getRoleTokenByUser('dummyuser', 'tenant0', 'yrn:yahoo:::tenant0:role:k2hr3_entest_obj_role_03', expire);
 				if(!apiutil.isSafeEntity(result) || !apiutil.isSafeEntity(result.result) || false === result.result){
 					clearAllToken(_alltoken);
 					_parentobj.timeout(_buptimeout);
@@ -186,8 +183,7 @@ exports.before = function(parentobj, alltoken, done)
 				alltoken.roletoken.tenant0_k2hr3_entest_obj_role_03 = 'R=' + result.token;
 
 				// Get role token for yrn:yahoo:::tenant0:role:test_service_tenant
-				base_id	= apiutil.convertHexString128ToBin64(unscopedtoken1);
-				result	= r3token.getRoleTokenByUser('dummyuser', 'tenant0', base_id, 'yrn:yahoo:::tenant0:role:test_service_tenant', expire);
+				result	= r3token.getRoleTokenByUser('dummyuser', 'tenant0', 'yrn:yahoo:::tenant0:role:test_service_tenant', expire);
 				if(!apiutil.isSafeEntity(result) || !apiutil.isSafeEntity(result.result) || false === result.result){
 					clearAllToken(_alltoken);
 					_parentobj.timeout(_buptimeout);
@@ -197,8 +193,7 @@ exports.before = function(parentobj, alltoken, done)
 				alltoken.roletoken.tenant0_test_service_tenant = 'R=' + result.token;
 
 				// Get role token for yrn:yahoo:::tenant1:role:test_service_owner
-				base_id	= apiutil.convertHexString128ToBin64(unscopedtoken1);
-				result	= r3token.getRoleTokenByUser('dummyuser', 'tenant1', base_id, 'yrn:yahoo:::tenant1:role:test_service_owner', expire);
+				result	= r3token.getRoleTokenByUser('dummyuser', 'tenant1', 'yrn:yahoo:::tenant1:role:test_service_owner', expire);
 				if(!apiutil.isSafeEntity(result) || !apiutil.isSafeEntity(result.result) || false === result.result){
 					clearAllToken(_alltoken);
 					_parentobj.timeout(_buptimeout);

--- a/test/auto_watcher.js
+++ b/test/auto_watcher.js
@@ -99,6 +99,52 @@ describe('PROCESS : WATHCER', function(){				// eslint-disable-line no-undef
 				done();
 			});
 	});
+
+	it('CHECK WATCHER RESULT : get k8s_test_role role which has only two IP addresses with response 200', function(done){	// eslint-disable-line no-undef
+		var	uri	= '/v1/role';
+		uri		+= '/k8s_test_role';													// path:	yrn:yahoo:::tenant0:role:k8s_test_role
+		uri		+= '?expand=false';														// expand:	false
+
+		chai.request(app)
+			.get(uri)
+			.set('content-type', 'application/json')
+			.set('x-auth-token', alltokens.scopedtoken.tenant0)							// tenant0
+			.end(function(err, res){
+				expect(res).to.have.status(200);
+				expect(res).to.be.json;
+				expect(res.body).to.be.an('object');
+				expect(res.body.result).to.be.a('boolean').to.be.true;
+				expect(res.body.message).to.be.a('null');
+				expect(res.body.role).to.be.an('object');
+				expect(res.body.role.hosts).to.be.an('object');
+				expect(res.body.role.hosts.hostnames).to.be.an.instanceof(Array).to.have.lengthOf(0);
+				expect(res.body.role.hosts.ips).to.be.an.instanceof(Array);
+
+				if(3 == res.body.role.hosts.ips.length){
+					// when run test:all, array is 3
+					expect(res.body.role.hosts.ips).to.be.an.instanceof(Array).to.have.lengthOf(3);
+					expect(res.body.role.hosts.ips[0]).to.be.a('string').to.equal('255.255.127.1 * eyJrOHNfY29udGFpbmVyX2lkIjoiMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEiLCJrOHNfazJocjNfcmFuZCI6ImFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjEiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMSIsIms4c19wb2RfaWQiOiJhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4xIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0xIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1');
+					expect(res.body.role.hosts.ips[1]).to.be.a('string').to.equal('255.255.127.2 * eyJrOHNfY29udGFpbmVyX2lkIjoiMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIiLCJrOHNfazJocjNfcmFuZCI6ImJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjIiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMiIsIms4c19wb2RfaWQiOiJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4yIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0yIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1');
+					expect(res.body.role.hosts.ips[2]).to.be.a('string').to.equal('255.255.127.3 * eyJrOHNfY29udGFpbmVyX2lkIjoiMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMiLCJrOHNfazJocjNfcmFuZCI6ImNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjMiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMyIsIms4c19wb2RfaWQiOiJjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYyIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4zIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0zIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1');
+
+				}else if(4 == res.body.role.hosts.ips.length){
+					// when run test:wacher as single testing, array is 4
+					expect(res.body.role.hosts.ips).to.be.an.instanceof(Array).to.have.lengthOf(4);
+					expect(res.body.role.hosts.ips[0]).to.be.a('string').to.equal('127.0.0.1 * eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ== k8s-auto-v1');
+					expect(res.body.role.hosts.ips[1]).to.be.a('string').to.equal('255.255.127.1 * eyJrOHNfY29udGFpbmVyX2lkIjoiMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEiLCJrOHNfazJocjNfcmFuZCI6ImFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjEiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMSIsIms4c19wb2RfaWQiOiJhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4xIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0xIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1');
+					expect(res.body.role.hosts.ips[2]).to.be.a('string').to.equal('255.255.127.2 * eyJrOHNfY29udGFpbmVyX2lkIjoiMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIiLCJrOHNfazJocjNfcmFuZCI6ImJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjIiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMiIsIms4c19wb2RfaWQiOiJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4yIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0yIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1');
+					expect(res.body.role.hosts.ips[3]).to.be.a('string').to.equal('255.255.127.3 * eyJrOHNfY29udGFpbmVyX2lkIjoiMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMiLCJrOHNfazJocjNfcmFuZCI6ImNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjMiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMyIsIms4c19wb2RfaWQiOiJjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYyIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4zIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0zIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 k8s-auto-v1');
+
+				}else{
+					// force do error
+					expect(res.body.role.hosts.ips).to.be.an.instanceof(Array).to.have.lengthOf(0);
+				}
+
+				done();
+			});
+	});
+
+
 });
 
 /*

--- a/test/k2hdkc_test.data
+++ b/test/k2hdkc_test.data
@@ -296,6 +296,14 @@
 #		yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip/127.3.2.1<\s>0
 #		yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip/__LOCAL_HOST_IP__<\s>0
 #
+####
+# yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04
+#	yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04/policies
+#		=> []
+#	yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04/hosts/name
+#	yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04/hosts/ip
+#		yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04/hosts/ip/__LOCAL_HOST_IP__<\s>0
+#
 ################################################################
 # SERVICE AND ETC
 ################################################################
@@ -321,7 +329,7 @@
 #   	=> enable
 #     yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner
 #       yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/id
-#        	=> [31100,31100,33301,33301]
+#        	=> "33333333-3333-4000-8000-333333330000"
 #       yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/policies
 #        	=> []
 #       yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/reference
@@ -332,7 +340,7 @@
 #         yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/hosts/ip
 #             => enable
 #           yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/hosts/ip/__LOCAL_HOST_IP__<\s>0
-#               => {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":[31100,31100,33301,33301]}
+#               => {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":"33333333-3333-4000-8000-333333330001"}
 #   yrn:yahoo:::__TENANT_NAME_SUB__:policy
 #   	=> enable
 #   yrn:yahoo:::__TENANT_NAME_SUB__:resource
@@ -349,7 +357,7 @@
 #     yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/@
 #         => ["yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role"]
 #     yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/id
-#         => [30111,30111,30300,30300]
+#         => "33333333-3333-4000-8000-333333330002"
 #     yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/policies
 #         => []
 #     yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/reference
@@ -360,7 +368,7 @@
 #       yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/hosts/ip
 #           => enable
 #         yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/hosts/ip/__LOCAL_HOST_IP__<\s>0
-#             => {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":[30111,30111,30300,30300]}
+#             => {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":"33333333-3333-4000-8000-333333330003"}
 #
 ###
 # yrn:yahoo:testservice
@@ -370,7 +378,7 @@
 #           => enable
 #         yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role
 #           yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role/id
-#               => [31111,31111,33300,33300]
+#               => "33333333-3333-4000-8000-333333330004"
 #           yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role/policies
 #               => ["yrn:yahoo:testservice::__TENANT_NAME_MAIN__:policy:acr-policy"]
 #           yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role/reference
@@ -381,7 +389,7 @@
 #             yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role/hosts/ip
 #                 => enable
 #               yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role/hosts/ip/__LOCAL_HOST_IP__<\s>0
-#                   => {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":[31111,31111,33300,33300]}
+#                   => {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":"33333333-3333-4000-8000-333333330005"}
 #       yrn:yahoo:testservice::__TENANT_NAME_MAIN__:policy
 #           => enable
 #         yrn:yahoo:testservice::__TENANT_NAME_MAIN__:policy:acr-policy
@@ -409,6 +417,65 @@
 ################################################################
 # IAAS & its IP in ROLE
 ################################################################
+# Cuk values for kubernetes
+#
+# cuk 1 =	"eyJrOHNfY29udGFpbmVyX2lkIjoiMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEiLCJrOHNfazJocjNfcmFuZCI6ImFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjEiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMSIsIms4c19wb2RfaWQiOiJhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4xIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0xIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9"
+# 		=>	base64 {
+# 				json {
+# 					k8s_container_id:		"11111111111111111111111111111111",
+# 					k8s_k2hr3_rand:			"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+# 					k8s_namespace:			"auto-test-namespace",
+# 					k8s_node_ip:			"255.255.127.1",
+# 					k8s_node_name:			"auto-test-node-1",
+# 					k8s_pod_id:				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+# 					k8s_pod_ip:				"255.127.127.1",
+# 					k8s_pod_name:			"auto-test-pod-1",
+# 					k8s_service_account:	"auto-test-sa"
+# 				}
+# 			}
+# cuk 2 =	"eyJrOHNfY29udGFpbmVyX2lkIjoiMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIiLCJrOHNfazJocjNfcmFuZCI6ImJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjIiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMiIsIms4c19wb2RfaWQiOiJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4yIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0yIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9"
+# 		=>	base64 {
+# 				json {
+# 					k8s_container_id:		"22222222222222222222222222222222",
+# 					k8s_k2hr3_rand:			"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+# 					k8s_namespace:			"auto-test-namespace",
+# 					k8s_node_ip:			"255.255.127.2",
+# 					k8s_node_name:			"auto-test-node-2",
+# 					k8s_pod_id:				"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+# 					k8s_pod_ip:				"255.127.127.2",
+# 					k8s_pod_name:			"auto-test-pod-2",
+# 					k8s_service_account:	"auto-test-sa"
+# 				}
+# 			}
+# cuk 3 =	"eyJrOHNfY29udGFpbmVyX2lkIjoiMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMiLCJrOHNfazJocjNfcmFuZCI6ImNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjMiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMyIsIms4c19wb2RfaWQiOiJjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYyIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4zIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0zIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9"
+# 		=>	base64 {
+# 				json {
+# 					k8s_container_id:		"33333333333333333333333333333333",
+# 					k8s_k2hr3_rand:			"cccccccccccccccccccccccccccccccc",
+# 					k8s_namespace:			"auto-test-namespace",
+# 					k8s_node_ip:			"255.255.127.3",
+# 					k8s_node_name:			"auto-test-node-3",
+# 					k8s_pod_id:				"cccccccccccccccccccccccccccccccc",
+# 					k8s_pod_ip:				"255.127.127.3",
+# 					k8s_pod_name:			"auto-test-pod-3",
+# 					k8s_service_account:	"auto-test-sa"
+# 				}
+# 			}
+# cuk 4 =	"eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ=="
+# 		=>	base64 {
+# 				json {
+# 					k8s_container_id:		"44444444444444444444444444444444",
+# 					k8s_k2hr3_rand:			"dddddddddddddddddddddddddddddddd",
+# 					k8s_namespace:			"auto-test-namespace",
+# 					k8s_node_ip:			"127.0.0.1",
+# 					k8s_node_name:			"auto-test-node-4",
+# 					k8s_pod_id:				"dddddddddddddddddddddddddddddddd",
+# 					k8s_pod_ip:				"127.0.0.1",
+# 					k8s_pod_name:			"auto-test-pod-4",
+# 					k8s_service_account:	"auto-test-sa"
+# 				}
+# 			}
+#
 #### IAAS Key
 # yrn:yahoo:::
 # 	yrn:yahoo::::iaas
@@ -420,18 +487,39 @@
 # 				yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/255.255.255.1 * auto-test-cuk
 # 				yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/255.255.255.2 * auto-test-cuk
 #
+# 			yrn:yahoo::::iaas:k8s:eyJrOHNfY29udGFpbmVyX2lkIjoiMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEiLCJrOHNfazJocjNfcmFuZCI6ImFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjEiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMSIsIms4c19wb2RfaWQiOiJhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4xIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0xIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9
+#				=> enable
+# 				yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/255.255.127.1 * eyJrOHNfY29udGFpbmVyX2lkIjoiMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEiLCJrOHNfazJocjNfcmFuZCI6ImFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjEiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMSIsIms4c19wb2RfaWQiOiJhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4xIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0xIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9
+# 			yrn:yahoo::::iaas:k8s:eyJrOHNfY29udGFpbmVyX2lkIjoiMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIiLCJrOHNfazJocjNfcmFuZCI6ImJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjIiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMiIsIms4c19wb2RfaWQiOiJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4yIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0yIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9
+#				=> enable
+# 				yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/255.255.127.2 * eyJrOHNfY29udGFpbmVyX2lkIjoiMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIiLCJrOHNfazJocjNfcmFuZCI6ImJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjIiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMiIsIms4c19wb2RfaWQiOiJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4yIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0yIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9
+# 			yrn:yahoo::::iaas:k8s:eyJrOHNfY29udGFpbmVyX2lkIjoiMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMiLCJrOHNfazJocjNfcmFuZCI6ImNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjMiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMyIsIms4c19wb2RfaWQiOiJjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYyIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4zIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0zIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9
+#				=> enable
+# 				yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/255.255.127.3 * eyJrOHNfY29udGFpbmVyX2lkIjoiMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMiLCJrOHNfazJocjNfcmFuZCI6ImNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjMiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMyIsIms4c19wb2RfaWQiOiJjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYyIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4zIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0zIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9
+# 			yrn:yahoo::::iaas:k8s:eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ==
+#				=> enable
+# 				yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/127.0.0.1 * eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ==
+#
 #### IP Key under Role
 # yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role
 #	yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts
 #		yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip
 # 			yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/127.0.0.1 * auto-test-cuk
-#				=> {"ip":"127.0.0.1","hostname":null,"port":0,"cuk":"auto-test-cuk","extra":"openstack-auto-v1","id":[11111,11111,11111,11111]}
+#				=> {"ip":"127.0.0.1","hostname":null,"port":0,"cuk":"auto-test-cuk","extra":"openstack-auto-v1","id":"11111111-1111-4000-8000-111111110000"}
 # 		 	yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/255.255.255.1 * auto-test-cuk
-#				=> {"ip":"255.255.255.1","hostname":null,"port":0,"cuk":"auto-test-cuk","deadat":"2404449632","extra":"openstack-auto-v1","id":[22222,22222,22222,22222]}
+#				=> {"ip":"255.255.255.1","hostname":null,"port":0,"cuk":"auto-test-cuk","deadat":"2404449632","extra":"openstack-auto-v1","id":"22222222-2222-4000-8000-222222220000"}
 # 		 	yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/255.255.255.2 * auto-test-cuk
-#				=> {"ip":"255.255.255.2","hostname":null,"port":0,"cuk":"auto-test-cuk","deadat":"0","extra":"openstack-auto-v1","id":[33333,33333,33333,33333]}
+#				=> {"ip":"255.255.255.2","hostname":null,"port":0,"cuk":"auto-test-cuk","deadat":"0","extra":"openstack-auto-v1","id":"33333333-3333-4000-8000-333333330000"}
 #
-
+# 		 	yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/255.255.127.1 * eyJrOHNfY29udGFpbmVyX2lkIjoiMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEiLCJrOHNfazJocjNfcmFuZCI6ImFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjEiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMSIsIms4c19wb2RfaWQiOiJhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4xIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0xIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9
+#				=> {"ip":"255.255.127.1","hostname":null,"port":0,"cuk":"eyJrOHNfY29udGFpbmVyX2lkIjoiMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEiLCJrOHNfazJocjNfcmFuZCI6ImFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjEiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMSIsIms4c19wb2RfaWQiOiJhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4xIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0xIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9","deadat":"0","extra":"k8s-auto-v1","id":"aaaaaaaa-aaaa-4000-8000-aaaaaaaa0000","k8s_container_id":"11111111111111111111111111111111","k8s_k2hr3_rand":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","k8s_namespace":"auto-test-namespace","k8s_node_ip":"255.255.127.1","k8s_node_name":"auto-test-node-1","k8s_pod_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","k8s_pod_ip":"255.127.127.1","k8s_pod_name":"auto-test-pod-1","k8s_service_account":"auto-test-sa"}
+# 		 	yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/255.255.127.2 * eyJrOHNfY29udGFpbmVyX2lkIjoiMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIiLCJrOHNfazJocjNfcmFuZCI6ImJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjIiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMiIsIms4c19wb2RfaWQiOiJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4yIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0yIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9
+#				=> {"ip":"255.255.127.2","hostname":null,"port":0,"cuk":"eyJrOHNfY29udGFpbmVyX2lkIjoiMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIiLCJrOHNfazJocjNfcmFuZCI6ImJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjIiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMiIsIms4c19wb2RfaWQiOiJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4yIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0yIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9","deadat":"0","extra":"k8s-auto-v1","id":"bbbbbbbb-bbbb-4000-8000-bbbbbbbb0000","k8s_container_id":"22222222222222222222222222222222","k8s_k2hr3_rand":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","k8s_namespace":"auto-test-namespace","k8s_node_ip":"255.255.127.2","k8s_node_name":"auto-test-node-2","k8s_pod_id":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","k8s_pod_ip":"255.127.127.2","k8s_pod_name":"auto-test-pod-2","k8s_service_account":"auto-test-sa"}
+# 		 	yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/255.255.127.3 * eyJrOHNfY29udGFpbmVyX2lkIjoiMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMiLCJrOHNfazJocjNfcmFuZCI6ImNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjMiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMyIsIms4c19wb2RfaWQiOiJjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYyIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4zIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0zIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9
+#				=> {"ip":"255.255.127.3","hostname":null,"port":0,"cuk":"eyJrOHNfY29udGFpbmVyX2lkIjoiMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMiLCJrOHNfazJocjNfcmFuZCI6ImNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjMiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMyIsIms4c19wb2RfaWQiOiJjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYyIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4zIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0zIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9","deadat":"0","extra":"k8s-auto-v1","id":"cccccccc-cccc-4000-8000-cccccccc0000","k8s_container_id":"33333333333333333333333333333333","k8s_k2hr3_rand":"cccccccccccccccccccccccccccccccc","k8s_namespace":"auto-test-namespace","k8s_node_ip":"255.255.127.3","k8s_node_name":"auto-test-node-3","k8s_pod_id":"cccccccccccccccccccccccccccccccc","k8s_pod_ip":"255.127.127.3","k8s_pod_name":"auto-test-pod-3","k8s_service_account":"auto-test-sa"}
+# 		 	yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/127.0.0.1 * eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ==
+#				=> {"ip":"127.0.0.1","hostname":null,"port":0,"cuk":"eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ==","deadat":"0","extra":"k8s-auto-v1","id":"cccccccc-cccc-4000-8000-cccccccc0000","k8s_container_id":"44444444444444444444444444444444","k8s_k2hr3_rand":"dddddddddddddddddddddddddddddddd","k8s_namespace":"auto-test-namespace","k8s_node_ip":"127.0.0.1","k8s_node_name":"auto-test-node-4","k8s_pod_id":"dddddddddddddddddddddddddddddddd","k8s_pod_ip":"127.0.0.1","k8s_pod_name":"auto-test-pod-4","k8s_service_account":"auto-test-sa"}
+#
 ################################################################
 # Clean keys
 ################################################################
@@ -453,6 +541,7 @@ rm yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01 all
 #rm yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02 all
 rm yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03 all
 rm yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03 all
+rm yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04 all
 
 ################################################################
 # Make yrn Tree
@@ -619,13 +708,13 @@ ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01 yrn:yahoo:::__
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/name enable
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/ip enable
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/name/host01.k2hr3_entest_str_01.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host01.k2hr3_entest_str_01.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":[11111,11111,11111,11111]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/name/host02.k2hr3_entest_str_01.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host02.k2hr3_entest_str_01.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":[11111,11111,22222,22222]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/ip/127.0.1.0 * " {"ip":"127.0.1.0","hostname":null,"port":0,"extra":null,"id":[11111,11111,11100,11100]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/ip/127.0.1.1 * " {"ip":"127.0.1.1","hostname":null,"port":0,"extra":null,"id":[11111,11111,22200,22200]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":[11111,11111,33300,33300]}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/name/host01.k2hr3_entest_str_01.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host01.k2hr3_entest_str_01.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":"11111111-1111-4000-8000-111111110001"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/name/host02.k2hr3_entest_str_01.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host02.k2hr3_entest_str_01.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":"11111111-1111-4000-8000-111111110002"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/ip/127.0.1.0 * " {"ip":"127.0.1.0","hostname":null,"port":0,"extra":null,"id":"11111111-1111-4000-8000-111111110003"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/ip/127.0.1.1 * " {"ip":"127.0.1.1","hostname":null,"port":0,"extra":null,"id":"11111111-1111-4000-8000-111111110004"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":"11111111-1111-4000-8000-111111110005"}
 ### id value is dummy
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/id [11111,11111,11111,11111]
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/id "11111111-1111-4000-8000-111111110006"
 ### reference must be bin, but this tool set only string. thus this value is dummy
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/reference 0
 
@@ -638,13 +727,13 @@ ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01 yrn:yahoo:::__
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/name enable
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/ip enable
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/name/host01.k2hr3_entest_obj_01.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host01.k2hr3_entest_obj_01.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":[11122,11122,11111,11111]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/name/host02.k2hr3_entest_obj_01.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host02.k2hr3_entest_obj_01.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":[11122,11122,22222,22222]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/ip/127.0.2.0 * " {"ip":"127.0.2.0","hostname":null,"port":0,"extra":null,"id":[11122,11122,11100,11100]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/ip/127.0.2.1 * " {"ip":"127.0.2.1","hostname":null,"port":0,"extra":null,"id":[11122,11122,22200,22200]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":[11122,11122,33300,33300]}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/name/host01.k2hr3_entest_obj_01.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host01.k2hr3_entest_obj_01.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":"11111111-1111-4000-8000-111111110007"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/name/host02.k2hr3_entest_obj_01.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host02.k2hr3_entest_obj_01.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":"11111111-1111-4000-8000-111111110008"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/ip/127.0.2.0 * " {"ip":"127.0.2.0","hostname":null,"port":0,"extra":null,"id":"11111111-1111-4000-8000-111111110009"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/ip/127.0.2.1 * " {"ip":"127.0.2.1","hostname":null,"port":0,"extra":null,"id":"11111111-1111-4000-8000-11111111000a"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":"11111111-1111-4000-8000-11111111000b"}
 ### id value is dummy
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/id [11122,11122,11111,11111]
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/id "11111111-1111-4000-8000-11111111000c"
 ### reference must be bin, but this tool set only string. thus this value is dummy
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/reference 0
 
@@ -657,13 +746,13 @@ ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_s
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/name enable
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/ip enable
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/name/host01.k2hr3_entest_str_02.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host01.k2hr3_entest_str_02.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":[22211,22211,11111,11111]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/name/host02.k2hr3_entest_str_02.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host02.k2hr3_entest_str_02.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":[22211,22211,22222,22222]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/ip/127.1.1.0 * " {"ip":"127.1.1.0","hostname":null,"port":0,"extra":null,"id":[22211,22211,11100,11100]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/ip/127.1.1.1 * " {"ip":"127.1.1.1","hostname":null,"port":0,"extra":null,"id":[22211,22211,22200,22200]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":[22211,22211,33300,33300]}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/name/host01.k2hr3_entest_str_02.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host01.k2hr3_entest_str_02.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":"22222222-2222-4000-8000-222222220000"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/name/host02.k2hr3_entest_str_02.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host02.k2hr3_entest_str_02.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":"22222222-2222-4000-8000-222222220001"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/ip/127.1.1.0 * " {"ip":"127.1.1.0","hostname":null,"port":0,"extra":null,"id":"22222222-2222-4000-8000-222222220002"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/ip/127.1.1.1 * " {"ip":"127.1.1.1","hostname":null,"port":0,"extra":null,"id":"22222222-2222-4000-8000-222222220003"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":"22222222-2222-4000-8000-222222220004"}
 ### id value is dummy
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/id [22211,22211,11111,11111]
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/id "22222222-2222-4000-8000-222222220005"
 ### reference must be bin, but this tool set only string. thus this value is dummy
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_01/k2hr3_entest_str_role_02/reference 0
 
@@ -676,13 +765,13 @@ ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_o
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/name enable
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/ip enable
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/name/host01.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host01.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":[22222,22222,11111,11111]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/name/host02.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host02.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":[22222,22222,22222,22222]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/ip/127.1.2.0 * " {"ip":"127.1.2.0","hostname":null,"port":0,"extra":null,"id":[22222,22222,11100,11100]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/ip/127.1.2.1 * " {"ip":"127.1.2.1","hostname":null,"port":0,"extra":null,"id":[22222,22222,22200,22200]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":[22222,22222,33300,33300]}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/name/host01.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host01.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":"22222222-2222-4000-8000-222222220006"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/name/host02.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host02.k2hr3_entest_obj_02.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":"22222222-2222-4000-8000-222222220007"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/ip/127.1.2.0 * " {"ip":"127.1.2.0","hostname":null,"port":0,"extra":null,"id":"22222222-2222-4000-8000-222222220008"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/ip/127.1.2.1 * " {"ip":"127.1.2.1","hostname":null,"port":0,"extra":null,"id":"22222222-2222-4000-8000-222222220009"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":"22222222-2222-4000-8000-22222222000a"}
 ### id value is dummy
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/id [22222,22222,11111,11111]
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/id "22222222-2222-4000-8000-22222222000b"
 ### reference must be bin, but this tool set only string. thus this value is dummy
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_01/k2hr3_entest_obj_role_02/reference 0
 
@@ -694,13 +783,13 @@ ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03 yrn:yahoo:::__
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/name enable
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/ip enable
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/name/host01.k2hr3_entest_str_03.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host01.k2hr3_entest_str_03.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":[33311,33311,11111,11111]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/name/host02.k2hr3_entest_str_03.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host02.k2hr3_entest_str_03.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":[33311,33311,22222,22222]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/ip/127.3.1.0 * " {"ip":"127.3.1.0","hostname":null,"port":0,"extra":null,"id":[33311,33311,11100,11100]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/ip/127.3.1.1 * " {"ip":"127.3.1.1","hostname":null,"port":0,"extra":null,"id":[33311,33311,22200,22200]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":[33311,33311,33300,33300]}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/name/host01.k2hr3_entest_str_03.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host01.k2hr3_entest_str_03.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":"33333333-3333-4000-8000-333333330000"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/name/host02.k2hr3_entest_str_03.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host02.k2hr3_entest_str_03.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":"33333333-3333-4000-8000-333333330001"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/ip/127.3.1.0 * " {"ip":"127.3.1.0","hostname":null,"port":0,"extra":null,"id":"33333333-3333-4000-8000-333333330002"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/ip/127.3.1.1 * " {"ip":"127.3.1.1","hostname":null,"port":0,"extra":null,"id":"33333333-3333-4000-8000-333333330003"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":"33333333-3333-4000-8000-333333330004"}
 ### id value is dummy
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/id [33311,33311,11111,11111]
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/id "33333333-3333-4000-8000-333333330005"
 ### reference must be bin, but this tool set only string. thus this value is dummy
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_str_role_03/reference 0
 
@@ -712,16 +801,30 @@ ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03 yrn:yahoo:::__
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/name enable
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip enable
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/name/host01.k2hr3_entest_obj_03.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host01.k2hr3_entest_obj_03.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":[33322,33322,11111,11111]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/name/host02.k2hr3_entest_obj_03.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host02.k2hr3_entest_obj_03.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":[33322,33322,22222,22222]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip/127.0.0.1 * " {"ip":"127.0.0.1","hostname":null,"port":0,"extra":null,"id":[33321,33321,11101,11101]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip/127.3.1.0 * " {"ip":"127.3.1.0","hostname":null,"port":0,"extra":null,"id":[33322,33322,11100,11100]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip/127.3.1.1 * " {"ip":"127.3.1.1","hostname":null,"port":0,"extra":null,"id":[33322,33322,22200,22200]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":[33322,33322,33300,33300]}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/name/host01.k2hr3_entest_obj_03.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host01.k2hr3_entest_obj_03.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":"33333333-3333-4000-8000-333333330006"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/name "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/name/host02.k2hr3_entest_obj_03.k2hr3.yahoo.co.jp * " {"ip":null,"hostname":"host02.k2hr3_entest_obj_03.k2hr3.yahoo.co.jp","port":0,"extra":null,"id":"33333333-3333-4000-8000-333333330007"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip/127.0.0.1 * " {"ip":"127.0.0.1","hostname":null,"port":0,"extra":null,"id":"33333333-3333-4000-8000-333333330008"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip/127.3.1.0 * " {"ip":"127.3.1.0","hostname":null,"port":0,"extra":null,"id":"33333333-3333-4000-8000-333333330009"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip/127.3.1.1 * " {"ip":"127.3.1.1","hostname":null,"port":0,"extra":null,"id":"33333333-3333-4000-8000-33333333000a"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":"33333333-3333-4000-8000-33333333000b"}
 ### id value is dummy
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/id [33322,33322,11111,11111]
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/id "33333333-3333-4000-8000-33333333000c"
 ### reference must be bin, but this tool set only string. thus this value is dummy
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_03/reference 0
+
+#
+# yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04
+#
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04 enable
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04/policies []
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04/hosts
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04/hosts yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04/hosts/name enable
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04/hosts yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04/hosts/ip enable
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04/hosts/ip/127.0.0.1 * " {"ip":"127.0.0.1","hostname":null,"port":0,"extra":null,"id":"33333333-3333-4000-8000-333333330009"}
+### id value is dummy
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04/id "33333333-3333-4000-8000-33333333000d"
+### reference must be bin, but this tool set only string. thus this value is dummy
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04 yrn:yahoo:::__TENANT_NAME_MAIN__:role:k2hr3_entest_obj_role_04/reference 0
 
 ################################################################
 # SERVICE AND ETC
@@ -746,14 +849,14 @@ ss yrn:yahoo:::__TENANT_NAME_SUB__ yrn:yahoo:::__TENANT_NAME_SUB__:service enabl
 ss yrn:yahoo:::__TENANT_NAME_SUB__:service yrn:yahoo::::service:testservice
 ss yrn:yahoo:::__TENANT_NAME_SUB__ yrn:yahoo:::__TENANT_NAME_SUB__:role enable
 ss yrn:yahoo:::__TENANT_NAME_SUB__:role yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner
-ss yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/id [31100,31100,33301,33301]
+ss yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/id "33333333-3333-4000-8000-33333333000d"
 ss yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/policies []
 ss yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/reference 0
 ss yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/hosts
 ss yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/hosts yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/hosts/name enable
 ss yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/hosts yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/hosts/ip enable
-ss yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/hosts/ip "yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/hosts/ip/127.0.0.1 * " {"ip":"127.0.0.1","hostname":null,"port":0,"extra":null,"id":[31101,31101,33302,33302]}
-ss yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/hosts/ip "yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":[31100,31100,33301,33301]}
+ss yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/hosts/ip "yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/hosts/ip/127.0.0.1 * " {"ip":"127.0.0.1","hostname":null,"port":0,"extra":null,"id":"33333333-3333-4000-8000-33333333000e"}
+ss yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/hosts/ip "yrn:yahoo:::__TENANT_NAME_SUB__:role:test_service_owner/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":"33333333-3333-4000-8000-33333333000f"}
 ss yrn:yahoo:::__TENANT_NAME_SUB__ yrn:yahoo:::__TENANT_NAME_SUB__:policy enable
 ss yrn:yahoo:::__TENANT_NAME_SUB__ yrn:yahoo:::__TENANT_NAME_SUB__:resource enable
 ss yrn:yahoo:::__TENANT_NAME_SUB__ yrn:yahoo:::__TENANT_NAME_SUB__:service enable
@@ -764,14 +867,14 @@ ss yrn:yahoo:::__TENANT_NAME_SUB__ yrn:yahoo:::__TENANT_NAME_SUB__:service enabl
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:service yrn:yahoo::::service:testservice
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/@ ["yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role"]
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/id [30111,30111,30300,30300]
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/id "33333333-3333-4000-8000-333333330010"
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/policies []
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/reference 0
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/hosts
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/hosts yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/hosts/name enable
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/hosts yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/hosts/ip enable
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/hosts/ip/127.1.0.1 * " {"ip":"127.1.0.1","hostname":null,"port":0,"extra":null,"id":[30112,30112,30302,30302]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":[30111,30111,30300,30300]}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/hosts/ip/127.1.0.1 * " {"ip":"127.1.0.1","hostname":null,"port":0,"extra":null,"id":"33333333-3333-4000-8000-333333330011"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:test_service_tenant/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":"33333333-3333-4000-8000-333333330012"}
 
 #
 # service in tenant : yrn:yahoo:testservice::__TENANT_NAME_MAIN__
@@ -787,8 +890,8 @@ ss yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role yrn:yahoo:testservi
 ss yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role/hosts
 ss yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role/hosts yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role/hosts/name enable
 ss yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role/hosts yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role/hosts/ip enable
-ss yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role/hosts/ip "yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":[31111,31111,33300,33300]}
-ss yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role/id [31111,31111,33300,33300]
+ss yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role/hosts/ip "yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role/hosts/ip/__LOCAL_HOST_IP__ * " {"ip":"__LOCAL_HOST_IP__","hostname":null,"port":0,"extra":null,"id":"33333333-3333-4000-8000-333333330013"}
+ss yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role/id "33333333-3333-4000-8000-333333330014"
 ss yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role yrn:yahoo:testservice::__TENANT_NAME_MAIN__:role:acr-role/reference 0
 
 ss yrn:yahoo:testservice::__TENANT_NAME_MAIN__ yrn:yahoo:testservice::__TENANT_NAME_MAIN__:policy enable
@@ -818,16 +921,56 @@ ss yrn:yahoo::::iaas:openstack:auto-test-cuk "yrn:yahoo:::__TENANT_NAME_MAIN__:r
 ss yrn:yahoo::::iaas:openstack:auto-test-cuk "yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/255.255.255.1 * auto-test-cuk"
 ss yrn:yahoo::::iaas:openstack:auto-test-cuk "yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/255.255.255.2 * auto-test-cuk"
 
+ss yrn:yahoo::::iaas           yrn:yahoo::::iaas:k8s               enable
+
+ss yrn:yahoo::::iaas:k8s yrn:yahoo::::iaas:k8s:eyJrOHNfY29udGFpbmVyX2lkIjoiMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEiLCJrOHNfazJocjNfcmFuZCI6ImFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjEiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMSIsIms4c19wb2RfaWQiOiJhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4xIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0xIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 enable
+ss yrn:yahoo::::iaas:k8s:eyJrOHNfY29udGFpbmVyX2lkIjoiMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEiLCJrOHNfazJocjNfcmFuZCI6ImFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjEiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMSIsIms4c19wb2RfaWQiOiJhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4xIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0xIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/hosts/ip/255.255.127.1 * eyJrOHNfY29udGFpbmVyX2lkIjoiMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEiLCJrOHNfazJocjNfcmFuZCI6ImFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjEiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMSIsIms4c19wb2RfaWQiOiJhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4xIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0xIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9"
+
+ss yrn:yahoo::::iaas:k8s yrn:yahoo::::iaas:k8s:eyJrOHNfY29udGFpbmVyX2lkIjoiMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIiLCJrOHNfazJocjNfcmFuZCI6ImJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjIiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMiIsIms4c19wb2RfaWQiOiJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4yIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0yIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 enable
+ss yrn:yahoo::::iaas:k8s:eyJrOHNfY29udGFpbmVyX2lkIjoiMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIiLCJrOHNfazJocjNfcmFuZCI6ImJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjIiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMiIsIms4c19wb2RfaWQiOiJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4yIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0yIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/hosts/ip/255.255.127.2 * eyJrOHNfY29udGFpbmVyX2lkIjoiMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIiLCJrOHNfazJocjNfcmFuZCI6ImJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjIiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMiIsIms4c19wb2RfaWQiOiJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4yIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0yIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9"
+
+ss yrn:yahoo::::iaas:k8s yrn:yahoo::::iaas:k8s:eyJrOHNfY29udGFpbmVyX2lkIjoiMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMiLCJrOHNfazJocjNfcmFuZCI6ImNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjMiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMyIsIms4c19wb2RfaWQiOiJjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYyIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4zIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0zIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 enable
+ss yrn:yahoo::::iaas:k8s:eyJrOHNfY29udGFpbmVyX2lkIjoiMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMiLCJrOHNfazJocjNfcmFuZCI6ImNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjMiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMyIsIms4c19wb2RfaWQiOiJjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYyIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4zIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0zIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9 "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/hosts/ip/255.255.127.3 * eyJrOHNfY29udGFpbmVyX2lkIjoiMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMiLCJrOHNfazJocjNfcmFuZCI6ImNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjMiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMyIsIms4c19wb2RfaWQiOiJjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYyIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4zIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0zIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9"
+
+ss yrn:yahoo::::iaas:k8s yrn:yahoo::::iaas:k8s:eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ==         enable
+ss yrn:yahoo::::iaas:k8s:eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ==         "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/hosts/ip/127.0.0.1 * eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ=="
+
 #
 # yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role
 #
 ss yrn:yahoo:::__TENANT_NAME_MAIN__                               yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role           yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/policies []
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role           yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/id        "66666666-6666-4000-8000-666666660000"
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role           yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/reference 0
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role           yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/policies  []
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role           yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts
 ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts     yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/127.0.0.1 * auto-test-cuk"     {"ip":"127.0.0.1","hostname":null,"port":0,"cuk":"auto-test-cuk","extra":"openstack-auto-v1","id":[11111,11111,11111,11111]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/255.255.255.1 * auto-test-cuk" {"ip":"255.255.255.1","hostname":null,"port":0,"cuk":"auto-test-cuk","deadat":"2404449632","extra":"openstack-auto-v1","id":[22222,22222,22222,22222]}
-ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/255.255.255.2 * auto-test-cuk" {"ip":"255.255.255.2","hostname":null,"port":0,"cuk":"auto-test-cuk","deadat":"0","extra":"openstack-auto-v1","id":[33333,33333,33333,33333]}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/127.0.0.1 * auto-test-cuk"     {"ip":"127.0.0.1","hostname":null,"port":0,"cuk":"auto-test-cuk","extra":"openstack-auto-v1","id":"44444444-4444-4000-8000-444444440000"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/255.255.255.1 * auto-test-cuk" {"ip":"255.255.255.1","hostname":null,"port":0,"cuk":"auto-test-cuk","deadat":"2404449632","extra":"openstack-auto-v1","id":"44444444-4444-4000-8000-444444440001"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:auto_test_role/hosts/ip/255.255.255.2 * auto-test-cuk" {"ip":"255.255.255.2","hostname":null,"port":0,"cuk":"auto-test-cuk","deadat":"0","extra":"openstack-auto-v1","id":"44444444-4444-4000-8000-444444440002"}
+
+#
+# yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role
+#
+ss yrn:yahoo:::__TENANT_NAME_MAIN__                              yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role           yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/id        "66666666-6666-4000-8000-666666660001"
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role           yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/reference 0
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role           yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/policies  []
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role           yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/hosts
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/hosts     yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/hosts/ip
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/hosts/ip/255.255.127.1 * eyJrOHNfY29udGFpbmVyX2lkIjoiMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEiLCJrOHNfazJocjNfcmFuZCI6ImFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjEiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMSIsIms4c19wb2RfaWQiOiJhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4xIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0xIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9" {"ip":"255.255.127.1","hostname":null,"port":0,"cuk":"eyJrOHNfY29udGFpbmVyX2lkIjoiMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTEiLCJrOHNfazJocjNfcmFuZCI6ImFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjEiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMSIsIms4c19wb2RfaWQiOiJhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYSIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4xIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0xIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9","deadat":"0","extra":"k8s-auto-v1","id":"aaaaaaaa-aaaa-4000-8000-aaaaaaaa0000","k8s_container_id":"11111111111111111111111111111111","k8s_k2hr3_rand":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","k8s_namespace":"auto-test-namespace","k8s_node_ip":"255.255.127.1","k8s_node_name":"auto-test-node-1","k8s_pod_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","k8s_pod_ip":"255.127.127.1","k8s_pod_name":"auto-test-pod-1","k8s_service_account":"auto-test-sa"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/hosts/ip/255.255.127.2 * eyJrOHNfY29udGFpbmVyX2lkIjoiMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIiLCJrOHNfazJocjNfcmFuZCI6ImJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjIiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMiIsIms4c19wb2RfaWQiOiJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4yIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0yIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9" {"ip":"255.255.127.2","hostname":null,"port":0,"cuk":"eyJrOHNfY29udGFpbmVyX2lkIjoiMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIiLCJrOHNfazJocjNfcmFuZCI6ImJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjIiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMiIsIms4c19wb2RfaWQiOiJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYiIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4yIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0yIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9","deadat":"0","extra":"k8s-auto-v1","id":"bbbbbbbb-bbbb-4000-8000-bbbbbbbb0000","k8s_container_id":"22222222222222222222222222222222","k8s_k2hr3_rand":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","k8s_namespace":"auto-test-namespace","k8s_node_ip":"255.255.127.2","k8s_node_name":"auto-test-node-2","k8s_pod_id":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","k8s_pod_ip":"255.127.127.2","k8s_pod_name":"auto-test-pod-2","k8s_service_account":"auto-test-sa"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/hosts/ip/255.255.127.3 * eyJrOHNfY29udGFpbmVyX2lkIjoiMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMiLCJrOHNfazJocjNfcmFuZCI6ImNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjMiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMyIsIms4c19wb2RfaWQiOiJjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYyIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4zIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0zIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9" {"ip":"255.255.127.3","hostname":null,"port":0,"cuk":"eyJrOHNfY29udGFpbmVyX2lkIjoiMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMiLCJrOHNfazJocjNfcmFuZCI6ImNjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjI1NS4yNTUuMTI3LjMiLCJrOHNfbm9kZV9uYW1lIjoiYXV0by10ZXN0LW5vZGUtMyIsIms4c19wb2RfaWQiOiJjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjYyIsIms4c19wb2RfaXAiOiIyNTUuMTI3LjEyNy4zIiwiazhzX3BvZF9uYW1lIjoiYXV0by10ZXN0LXBvZC0zIiwiazhzX3NlcnZpY2VfYWNjb3VudCI6ImF1dG8tdGVzdC1zYSJ9","deadat":"0","extra":"k8s-auto-v1","id":"cccccccc-cccc-4000-8000-cccccccc0000","k8s_container_id":"33333333333333333333333333333333","k8s_k2hr3_rand":"cccccccccccccccccccccccccccccccc","k8s_namespace":"auto-test-namespace","k8s_node_ip":"255.255.127.3","k8s_node_name":"auto-test-node-3","k8s_pod_id":"cccccccccccccccccccccccccccccccc","k8s_pod_ip":"255.127.127.3","k8s_pod_name":"auto-test-pod-3","k8s_service_account":"auto-test-sa"}
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/hosts/ip "yrn:yahoo:::__TENANT_NAME_MAIN__:role:k8s_test_role/hosts/ip/127.0.0.1 * eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ=="     {"ip":"127.0.0.1","hostname":null,"port":0,"cuk":"eyJrOHNfY29udGFpbmVyX2lkIjoiNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQiLCJrOHNfazJocjNfcmFuZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX25hbWVzcGFjZSI6ImF1dG8tdGVzdC1uYW1lc3BhY2UiLCJrOHNfbm9kZV9pcCI6IjEyNy4wLjAuMSIsIms4c19ub2RlX25hbWUiOiJhdXRvLXRlc3Qtbm9kZS00IiwiazhzX3BvZF9pZCI6ImRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkIiwiazhzX3BvZF9pcCI6IjEyNy4wLjAuMSIsIms4c19wb2RfbmFtZSI6ImF1dG8tdGVzdC1wb2QtNCIsIms4c19zZXJ2aWNlX2FjY291bnQiOiJhdXRvLXRlc3Qtc2EifQ==","deadat":"0","extra":"k8s-auto-v1","id":"cccccccc-cccc-4000-8000-cccccccc0000","k8s_container_id":"44444444444444444444444444444444","k8s_k2hr3_rand":"dddddddddddddddddddddddddddddddd","k8s_namespace":"auto-test-namespace","k8s_node_ip":"127.0.0.1","k8s_node_name":"auto-test-node-4","k8s_pod_id":"dddddddddddddddddddddddddddddddd","k8s_pod_ip":"127.0.0.1","k8s_pod_name":"auto-test-pod-4","k8s_service_account":"auto-test-sa"}
+
+#
+# yrn:yahoo:::__TENANT_NAME_MAIN__:role:autotest_del_k8s_role
+#
+ss yrn:yahoo:::__TENANT_NAME_MAIN__                                  yrn:yahoo:::__TENANT_NAME_MAIN__:role:autotest_del_k8s_role
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:autotest_del_k8s_role       yrn:yahoo:::__TENANT_NAME_MAIN__:role:autotest_del_k8s_role/id        "66666666-6666-4000-8000-666666660002"
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:autotest_del_k8s_role       yrn:yahoo:::__TENANT_NAME_MAIN__:role:autotest_del_k8s_role/reference 0
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:autotest_del_k8s_role       yrn:yahoo:::__TENANT_NAME_MAIN__:role:autotest_del_k8s_role/policies  []
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:autotest_del_k8s_role       yrn:yahoo:::__TENANT_NAME_MAIN__:role:autotest_del_k8s_role/hosts     enable
+ss yrn:yahoo:::__TENANT_NAME_MAIN__:role:autotest_del_k8s_role/hosts yrn:yahoo:::__TENANT_NAME_MAIN__:role:autotest_del_k8s_role/hosts/ip  enable
 
 exit
 ################################################################

--- a/test/manual_resource_postput.js
+++ b/test/manual_resource_postput.js
@@ -65,7 +65,7 @@ function postV1Resource(method, token, querypath, name, datatype, data, reskeys,
 		// case for POST
 		if(apiutil.compareCaseString('object', datatype)){
 			// If datatype is object, data is needed to decode JSON to object here.
-			data = JSON.parse(data);
+			data = apiutil.parseJSON(data);
 		}
 
 		/* eslint-disable indent, no-mixed-spaces-and-tabs */

--- a/test/manual_role_delete.js
+++ b/test/manual_role_delete.js
@@ -125,7 +125,7 @@ function deleteV1Role(token, name, target_host, port, cuk)
 //
 // Request API for test
 //
-function deleteV1_IPByCuk(addrs, cuk)
+function deleteV1_IPByCuk(addrs, port, cuk)
 {
 	/* eslint-disable indent, no-mixed-spaces-and-tabs */
 	var	headers		= {
@@ -150,7 +150,11 @@ function deleteV1_IPByCuk(addrs, cuk)
 		urlarg		+= cuk;
 		already_set	= true;
 	}
-	urlarg			+= already_set ? '&extra=openstack-auto-v1' : '?extra=openstack-auto-v1';
+	if(null !== port && !isNaN(port)){
+		urlarg		+= already_set ? '&port=' : '?port=';
+		urlarg		+= String(port);
+		already_set	= true;
+	}
 
 	/* eslint-disable indent, no-mixed-spaces-and-tabs */
 	var	options		= {	'host':				hostname,
@@ -251,7 +255,7 @@ cliutil.getConsoleInput('Delete ROLE/TOKEN(role)/HOST(name or ip)/IP/CUK : ', tr
 				}
 			}
 
-			cliutil.getConsoleInput('Delete by CUK                                   : ', true, false, function(isbreak, cuk)
+			cliutil.getConsoleInput('Delete by CUK(allow empty)                      : ', true, false, function(isbreak, cuk)
 			{
 				if(isbreak){
 					process.exit(0);
@@ -261,8 +265,19 @@ cliutil.getConsoleInput('Delete ROLE/TOKEN(role)/HOST(name or ip)/IP/CUK : ', tr
 					_cuk = cuk.trim();
 				}
 
-				// run
-				deleteV1_IPByCuk(_addrs, _cuk);
+				cliutil.getConsoleInput('Delete by port(allow empty)                     : ', true, false, function(isbreak, port)
+				{
+					if(isbreak){
+						process.exit(0);
+					}
+					var	_port = null;
+					if(!isNaN(port)){
+						_port = parseInt(port);
+					}
+
+					// run
+					deleteV1_IPByCuk(_addrs, _port, _cuk);
+				});
 			});
 		});
 

--- a/test/manual_role_postput.js
+++ b/test/manual_role_postput.js
@@ -369,9 +369,13 @@ function inputHostType(method)
 					if(isbreak){
 						process.exit(0);
 					}
-					var	_port = parseInt(port);
 
-					if(port !== String(_port) && _port < 0){
+					var	_port;
+					if(null === port || !apiutil.isSafeString(port)){
+						_port = 0;
+					}else if(!isNaN(port)){
+						_port = parseInt(port);
+					}else{
 						console.log('port number must be decimal number: ' + JSON.stringify(port));
 						process.exit(0);
 					}
@@ -416,7 +420,7 @@ function inputHostType(method)
 
 							}else if(apiutil.compareCaseString('string', is_extra) || apiutil.compareCaseString('str', is_extra)){
 
-								cliutil.getConsoleInput('     Extra data for host(specify string)              : \n', true, true, function(isbreak, extra)
+								cliutil.getConsoleInput('     Extra data - null/openstack(os)/kubernetes(k8s)  : ', true, false, function(isbreak, extra)
 								{
 									if(isbreak){
 										process.exit(0);
@@ -425,6 +429,10 @@ function inputHostType(method)
 
 									if('' === apiutil.getSafeString(extra) || apiutil.compareCaseString('null', apiutil.getSafeString(extra))){
 										_extra = null;
+									}else if(apiutil.compareCaseString('os', apiutil.getSafeString(extra)) || apiutil.compareCaseString('openstack', apiutil.getSafeString(extra))){
+										_extra = 'openstack-auto-v1';
+									}else if(apiutil.compareCaseString('k8s', apiutil.getSafeString(extra)) || apiutil.compareCaseString('kubernetes', apiutil.getSafeString(extra))){
+										_extra = 'k8s-auto-v1';
 									}else{
 										_extra = extra;
 									}


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
Supported kubernetes as IaaS and also related changes were made.

### Supports kubernetes pod and container for role member
Added support for automatic registration and deletion of ROLE members from Pods in kubernetes as IaaS.  
Therefore, some K2HR3 REST APIs have been modified and added while maintaining backward compatibility.

### Changed ID management and TOKEN (based on UUID4) enhancement
The internal ID used has been changed to UUID4.

