### PR TITLE
Added authorization using Token from external authentication system

### DIFF
--- a/lib/dummyuserapi.js
+++ b/lib/dummyuserapi.js
@@ -714,6 +714,16 @@ exports.getUserUnscopedToken = function(uname, passwd, callback)
 };
 
 //
+// update token	: not implemented
+//
+exports.getUserUnscopedTokenByToken = function(token, callback)		// eslint-disable-line no-unused-vars
+{
+	var	error = new Error('getUserUnscopedTokenByToken is not implemented');
+	r3logger.elog(error.message);
+	callback(error, null);
+};
+
+//
 // tenantid		: not used
 //
 // [NOTE]

--- a/lib/k2hr3tokens.js
+++ b/lib/k2hr3tokens.js
@@ -112,6 +112,56 @@ function rawGetUserToken(user, passwd, tenant, callback)
 	});
 }
 
+//---------------------------------------------------------
+// Get User Token from token issued by another authentication system
+//---------------------------------------------------------
+// 
+// Get scoped/unscoped user token from token issued by another authentication system
+// (ex. openstack identity token which is not registered in k2hr3 yet.)
+// 
+function rawGetUserTokenByToken(token, tenant, callback)
+{
+	var	_callback = callback;
+
+	if(!apiutil.isSafeString(token)){
+		var	error = new Error('token parameter is wrong');
+		r3logger.elog(error.message);
+		_callback(error, null);
+		return;
+	}
+
+	var	_tenant		= apiutil.isSafeString(tenant) ? tenant.toLowerCase() : '';
+	var	_orgtoken	= token;
+
+	// get unscoped token
+	rawGetUserUnscopedTokenbyTokenWrap(_orgtoken, function(err, jsonres)
+	{
+		var	error;
+		if(null !== err){
+			error = new Error('could not get user access token by ' + err.message);
+			r3logger.elog(error.message);
+			_callback(error, null);
+			return;
+		}
+
+		// save to local val
+		var	_userid			= jsonres.userid;
+		var	_username		= jsonres.user;
+		var	_unscopedtoken	= jsonres.token;
+		var	_tokenexpire	= jsonres.expire;							// eslint-disable-line no-unused-vars
+		var	_region			= jsonres.region;							// eslint-disable-line no-unused-vars
+
+		// break when unscoped token
+		if(!apiutil.isSafeString(_tenant)){
+			_callback(null, _unscopedtoken);
+			return;
+		}
+
+		// get scoped user token
+		return rawGetScopedUserToken(_unscopedtoken, _username, _userid, _tenant, _callback);
+	});
+}
+
 // 
 // Get scoped user token from unscoped user token
 // 
@@ -375,6 +425,66 @@ function rawGetUserUnscopedTokenWrap(user, passwd, callback)
 
 	// get unscoped token
 	osapi.getUserUnscopedToken(_user, _passwd, function(err, jsonres)
+	{
+		var	error;
+		if(null !== err){
+			error = new Error('could not get user access token by ' + err.message);
+			r3logger.elog(error.message);
+			_callback(error, null);
+			return;
+		}
+
+		// init user
+		var	resobj = k2hr3.initUser(jsonres.user, jsonres.userid, jsonres.user, null);
+		if(!resobj.result){
+			error = new Error(resobj.message);
+			r3logger.elog(error.message);
+			_callback(error, null);
+			return;
+		}
+
+		// set unscoped token
+		var	token_seed = apiutil.isSafeString(jsonres.token_seed) ? jsonres.token_seed : null;
+		if(!rawSetUserToken(jsonres.user, null, jsonres.token, jsonres.expire, jsonres.region, token_seed)){
+			error = new Error('failed to set unscoped/scoped user token');
+			r3logger.elog(error.message);
+			_callback(error, null);
+			return;
+		}
+
+		// succeed
+		_callback(null, jsonres);
+		return;
+	});
+}
+
+//---------------------------------------------------------
+// get user unscoped token from token issued by another authentication system
+//---------------------------------------------------------
+// 
+// Get user token from token issued by another authentication system
+//
+//	result		null or object
+//				{
+//					user:		user name(if existed, from parameter)
+//					userid:		user id(if existed, from "yrn:yahoo::::user:<user name>:id")
+//					scoped:		false(always false)
+//					token:		token string(id)
+//					expire:		expire string(if existed, null)
+//					region:		region string
+//				}
+//
+// [NOTE]
+// This function is wrapper for osapi.getUserUnscopedTokenByToken().
+// This function checks existing unscoped token before call it.
+//
+function rawGetUserUnscopedTokenbyTokenWrap(token, callback)
+{
+	var	_orgtoken	= token;
+	var	_callback	= callback;
+
+	// get unscoped token
+	osapi.getUserUnscopedTokenByToken(_orgtoken, function(err, jsonres)
 	{
 		var	error;
 		if(null !== err){
@@ -2619,6 +2729,11 @@ function rawIsRoleAuthToken(req)
 exports.getUserToken = function(user, passwd, tenant, callback)
 {
 	return rawGetUserToken(user, passwd, tenant, callback);
+};
+
+exports.getUserTokenByToken = function(token, tenant, callback)
+{
+	return rawGetUserTokenByToken(token, tenant, callback);
 };
 
 exports.getScopedUserToken = function(unscopedtoken, username, tenant, callback)

--- a/lib/openstackapiv2.js
+++ b/lib/openstackapiv2.js
@@ -711,6 +711,16 @@ exports.getUserUnscopedToken = function(uname, passwd, callback)
 };
 
 //
+// update token	: not implemented
+//
+exports.getUserUnscopedTokenByToken = function(token, callback)			// eslint-disable-line no-unused-vars
+{
+	var	error = new Error('getUserUnscopedTokenByToken is not implemented');
+	r3logger.elog(error.message);
+	callback(error, null);
+};
+
+//
 // tenantname	: for keystone v2 api
 // tenantid		: not used
 //

--- a/lib/openstackapiv3.js
+++ b/lib/openstackapiv3.js
@@ -236,6 +236,197 @@ function rawGetUserUnscopedTokenV3(uname, passwd, callback)
 }
 
 //
+// Get Unscoped token by openstack token from Openstack identity v3 API
+//
+// Document:	 https://docs.openstack.org/api-ref/identity/v3/?expanded=token-authentication-with-unscoped-authorization-detail#token-authentication-with-unscoped-authorization
+//
+// Request:		{
+//					"auth": {
+//						"identity": {
+//							"methods": [
+//								"token"
+//							],
+//							"token": {
+//								"id": "**********"
+//							}
+//						}
+//					}
+//				}
+//
+//
+// Response:
+//		Header	"X-Subject-Token: 16e4638398574f1d9364............"			(*1)
+//				{
+//					"token": {
+//						"audit_ids": [
+//							"################....."
+//						],
+//						"expires_at": "2017-06-17T00:20:38.863072Z",		(*2)
+//						"issued_at": "2015-11-05T21:00:33.819948Z",
+//						"methods": [
+//							"token"
+//						],
+//						"user": {
+//							"domain": {
+//								"id": "default",
+//								"name": "Default"
+//							},
+//							"id":	"*****************************...",		(*4)
+//							"name":	"user name"								(*3)
+//							"password_expires_at": null
+//						}
+//					}
+//				}
+//
+// callback(error, result):
+//				result = {
+//					user:		user name									(*3)
+//					userid:		user id										(*4)
+//					scoped:		false										(always false)
+//					token:		token string(id)							(*1)
+//					expire:		expire string								(*2)
+//					region:		region string								(region name for keystone endpoint)
+//					token_seed:	seed										({publisher: 'OPENSTACKV3'})
+//				}
+//
+function rawGetUserUnscopedTokenByOstokenV3(ostoken, callback)
+{
+	if(!apiutil.isSafeString(ostoken)){
+		var	error = new Error('some parameter is wrong : ostoken=' + JSON.stringify(ostoken));
+		r3logger.elog(error.message);
+		callback(error, null);
+		return;
+	}
+	var	_ostoken	= ostoken;
+	var	_callback	= callback;
+
+	// get end points for keystone
+	osksep.getKeystoneEndpoint(function(err, keystone_ep)
+	{
+		if(null !== err){
+			var	error = new Error('could not get keystone end point by ' + err.message);
+			r3logger.elog(error.message);
+			_callback(error, null);
+			return;
+		}
+		// got safe endpoint for keystone
+		//r3logger.dlog(keystone_ep);
+
+		// build parameters for request
+		/* eslint-disable indent, no-mixed-spaces-and-tabs */
+		var	body	= {	'auth': {
+							'identity': {
+									'token': {
+										'id': _ostoken,
+									},
+									'methods': ['token']
+								}
+							}
+						};
+		var	strbody	= JSON.stringify(body);
+		var	headers	= {
+						'Content-Type':		'application/json',
+						'Content-Length':	strbody.length
+					  };
+		var	options	= {	'host':				keystone_ep.hostname,
+						'port':				keystone_ep.port,
+						'path': 			keystone_ep.pathname + '/v3/auth/tokens',
+						'method':			'POST',
+						'headers':			headers
+					  };
+		/* eslint-enable indent, no-mixed-spaces-and-tabs */
+
+		var	httpobj;
+		if(apiutil.compareCaseString('https:', keystone_ep.protocol)){
+			if(null !== cacerts.ca){
+				options.ca = cacerts.ca;
+			}
+			options.agent	= new https.Agent(options);
+			httpobj			= https;
+		}else{
+			options.agent	= new http.Agent(options);
+			httpobj			= http;
+		}
+
+		// send request
+		var	req = httpobj.request(options, function(res)
+		{
+			var	body	= '';
+			var	status	= res.statusCode;
+			var	headers	= res.headers;
+			var	error;
+
+			r3logger.dlog('response status: ' + res.statusCode);
+			r3logger.dlog('response header: ' + JSON.stringify(res.headers));
+			res.setEncoding('utf8');
+
+			res.on('data', function(chunk)
+			{
+				//r3logger.dlog('response chunk: ' + chunk);
+				body += chunk;
+			});
+
+			res.on('end', function(result)								// eslint-disable-line no-unused-vars
+			{
+				if(300 <= status){
+					error = new Error('could not get unscoped token by status=' + String(status));
+					r3logger.elog(error.message);
+					_callback(error, null);
+					return;
+				}
+				if(!apiutil.isSafeEntity(headers) || !apiutil.isSafeString(headers['x-subject-token'])){
+					error = new Error('could not find unscoped token in header(X-Subject-Token)');
+					r3logger.elog(error.message);
+					_callback(error, null);
+					return;
+				}
+				//r3logger.dlog('response body: ' + body);
+
+				var	res_body = body;
+				if(apiutil.checkSimpleJSON(body)){
+					res_body = JSON.parse(body);
+				}
+				if(	!apiutil.isSafeEntity(res_body)					||
+					!apiutil.isSafeEntity(res_body.token)			||
+					!apiutil.isSafeString(res_body.token.expires_at)||
+					!apiutil.isSafeEntity(res_body.token.user)		||
+					!apiutil.isSafeString(res_body.token.user.id)	||
+					!apiutil.isSafeString(res_body.token.user.name)	)
+				{
+					error = new Error('could not get unscoped token by something wrong response body : ' + body);
+					r3logger.elog(error.message);
+					_callback(error, null);
+					return;
+				}
+
+				// convert openstack user id(16 bytes hex string) to UUID(not UUID4)
+				var	user_id_uuid4	= apiutil.cvtNumberStringToUuid4(res_body.token.user.id, 16);
+
+				// build result
+				var	resobj			= {};
+				resobj.user			= res_body.token.user.name.toLowerCase();
+				resobj.userid		= user_id_uuid4;
+				resobj.scoped		= false;
+				resobj.token		= headers['x-subject-token'];
+				resobj.expire		= res_body.token.expires_at;
+				resobj.region		= keystone_ep.region.toLowerCase();
+				resobj.token_seed	= JSON.stringify({ publisher: 'OPENSTACKV3' });
+				_callback(null, resobj);
+			});
+		});
+		req.on('error', function(exception) {
+			r3logger.elog('problem with request: ' + exception.message);
+			_callback(exception);
+			return;
+		});
+
+		// write data to request body
+		req.write(strbody);
+		req.end();
+	}, true);
+}
+
+//
 // Get Scoped token by unscoped token and tenant name from Openstack identity v3 API
 //
 // Document:	 https://developer.openstack.org/api-ref/identity/v3/?expanded=token-authentication-with-scoped-authorization-detail
@@ -786,6 +977,14 @@ function rawGetUserTenantListV3(unscopedtoken, userid, callback)
 exports.getUserUnscopedToken = function(uname, passwd, callback)
 {
 	return rawGetUserUnscopedTokenV3(uname, passwd, callback);
+};
+
+//
+// token	: unscoped/scoped token for openstack
+//
+exports.getUserUnscopedTokenByToken = function(token, callback)
+{
+	return rawGetUserUnscopedTokenByOstokenV3(token, callback);
 };
 
 //

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "chai-http": "^4.2.1",
-    "eslint": "^7.5.0",
-    "mocha": "^8.0.1",
+    "eslint": "^7.7.0",
+    "mocha": "^8.1.2",
     "nyc": "^15.1.0",
     "publish-please": "^5.5.1"
   },

--- a/test/auto_usertokens.js
+++ b/test/auto_usertokens.js
@@ -208,7 +208,7 @@ describe('API : USER TOKEN', function(){				// eslint-disable-line no-undef
 			});
 	});
 
-	it('POST /v1/user/tokens : failure scoped token by invalid unscoped token with status 401', function(done){						// eslint-disable-line no-undef
+	it('POST /v1/user/tokens : failure scoped token by invalid unscoped token with status 404', function(done){						// eslint-disable-line no-undef
 		chai.request(app)
 			.post('/v1/user/tokens')
 			.set('content-type', 'application/json')
@@ -219,11 +219,11 @@ describe('API : USER TOKEN', function(){				// eslint-disable-line no-undef
 				}
 			})
 			.end(function(err, res){
-				expect(res).to.have.status(401);
+				expect(res).to.have.status(404);
 				expect(res).to.be.json;
 				expect(res.body).to.be.an('object');
 				expect(res.body.result).to.be.a('boolean').to.be.false;
-				expect(res.body.message).to.be.a('string').to.equal('token(error_dummy_token) is not existed, because it is expired or not set yet.');
+				expect(res.body.message).to.be.a('string').to.equal('could not get scoped user token for other token, tenant=tenant0 by could not get user access token by could not get user access token by getUserUnscopedTokenByToken is not implemented');
 
 				done();
 			});
@@ -334,7 +334,7 @@ describe('API : USER TOKEN', function(){				// eslint-disable-line no-undef
 				expect(res).to.be.json;
 				expect(res.body).to.be.an('object');
 				expect(res.body.result).to.be.a('boolean').to.be.false;
-				expect(res.body.message).to.be.a('string').to.equal('POST body does not have tenant name(or user credentials)');
+				expect(res.body.message).to.be.a('string').to.equal('There is no x-auth-token header');
 
 				done();
 			});
@@ -378,7 +378,7 @@ describe('API : USER TOKEN', function(){				// eslint-disable-line no-undef
 			});
 	});
 
-	it('PUT /v1/user/tokens : failure scoped token by invalid unscoped token with status 401', function(done){						// eslint-disable-line no-undef
+	it('PUT /v1/user/tokens : failure scoped token by invalid unscoped token with status 404', function(done){						// eslint-disable-line no-undef
 		let	url	= '/v1/user/tokens';
 		url		+= '?tenantname=tenant0';
 		chai.request(app)
@@ -386,11 +386,11 @@ describe('API : USER TOKEN', function(){				// eslint-disable-line no-undef
 			.set('content-type', 'application/json')
 			.set('x-auth-token', 'error_dummy_token')
 			.end(function(err, res){
-				expect(res).to.have.status(401);
+				expect(res).to.have.status(404);
 				expect(res).to.be.json;
 				expect(res.body).to.be.an('object');
 				expect(res.body.result).to.be.a('boolean').to.be.false;
-				expect(res.body.message).to.be.a('string').to.equal('token(error_dummy_token) is not existed, because it is expired or not set yet.');
+				expect(res.body.message).to.be.a('string').to.equal('could not get scoped user token for other token, tenant=tenant0 by could not get user access token by could not get user access token by getUserUnscopedTokenByToken is not implemented');
 
 				done();
 			});


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
Specifications have been added(feature added) to the Token API of the K2HR3 API.

K2HR3 Token API is an API that receives the user's Credential and outputs an Unscoped Token.
And the API can also receive this UnscopedToken and output the ScopedToken.
In additional, for this user authentication(token API), it is possible to use K2HR3 dedicated authentication authorization, delegate to OpenStack (Identity), or delegate to other systems.

This PR adds a function that can be used to output UnscopedToken and ScopedToken of K2HR3 using UnscopedToken or ScopedToken of OpenStack when delegating to OpenStack.
As a result, in the case of OpenStack, it becomes possible to use the Token of OpenStack in addition to the user Credential to operate the API.
