### PR TITLE
Supported Node.js 12 and 14

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -1,6 +1,6 @@
 {
   "validations": {
-    "vulnerableDependencies": false,
+    "vulnerableDependencies": true,
     "uncommittedChanges": false,
     "untrackedFiles": false,
     "sensitiveData": false,

--- a/test/auto_acr.js
+++ b/test/auto_acr.js
@@ -806,7 +806,7 @@ describe('API : ACR', function(){						// eslint-disable-line no-undef
 				expect(res.body.result).to.be.a('boolean').to.be.false;
 				expect(res.body.message).to.be.a('string');
 				expect(res.body.message).to.satisfy(function(message){
-					return (-1 != message.indexOf('connect ECONNREFUSED') || -1 != message.indexOf('got error response for verify request by status=401'));
+					return (-1 != message.indexOf('connect ECONNREFUSED') || -1 != message.indexOf('got error response for verify request by status=401') || -1 != message.indexOf('parameter is wrong : verifyurl='));
 				});
 
 				done();
@@ -1051,7 +1051,7 @@ describe('API : ACR', function(){						// eslint-disable-line no-undef
 				expect(res.body.result).to.be.a('boolean').to.be.false;
 				expect(res.body.message).to.be.a('string');
 				expect(res.body.message).to.satisfy(function(message){
-					return (-1 != message.indexOf('connect ECONNREFUSED') || -1 != message.indexOf('got error response for verify request by status=401'));
+					return (-1 != message.indexOf('connect ECONNREFUSED') || -1 != message.indexOf('got error response for verify request by status=401') || -1 != message.indexOf('parameter is wrong : verifyurl='));
 				});
 
 				done();


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### New support for Node.js 12/14.
As a result, the source code is ready to be built with Node.js 8/10/12/14.
### vulnerableDependencies setting
vulnerableDependencies were set to false because there was a vulnerability in the lodash package on which the publish-please package depends.
However, this problem has now been resolved, so I changed it to true.
