### PR TITLE
Updated packages and fixed bugs

### DIFF
--- a/.auditignore
+++ b/.auditignore
@@ -1,0 +1,1 @@
+https://npmjs.com/advisories/1673

--- a/.github/workflows/nodejs_helper.sh
+++ b/.github/workflows/nodejs_helper.sh
@@ -414,6 +414,7 @@ BUILD_SRCTOP="/tmp/${TMPSRCTOP}"
 #
 # Change current directory
 #
+echo "[INFO] ${PRGNAME} : Change current directory to ${BUILD_SRCTOP}"
 run_cmd cd ${BUILD_SRCTOP}
 
 #

--- a/lib/k2hr3config.js
+++ b/lib/k2hr3config.js
@@ -640,7 +640,7 @@ var R3ApiConfig = (function()
 			return logstream;
 		}
 		try{
-			logstream = rotatefs(filename, this.loadedConfig.logrotateopt);
+			logstream = rotatefs.createStream(filename, this.loadedConfig.logrotateopt);
 		}catch(error){
 			console.warn('Could not create log rotate option by : ' + JSON.stringify(error.message));
 			logstream = null;

--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "version": "1.0.0",
   "dependencies": {
     "body-parser": "^1.19.0",
-    "config": "^3.3.2",
+    "config": "^3.3.6",
     "cookie-parser": "~1.4.5",
-    "dateformat": "^4.0.0",
-    "debug": "~4.3.1",
+    "dateformat": "^4.5.1",
+    "debug": "~4.3.2",
     "express": "^4.17.1",
-    "k2hdkc": "^0.9.10",
+    "k2hdkc": "^1.0.2",
     "morgan": "~1.10.0",
-    "rotating-file-stream": "^2.1.3"
+    "rotating-file-stream": "^2.1.5"
   },
   "bin": {
     "k2hr3-api": "./bin/www",
@@ -26,10 +26,10 @@
     "test": "test"
   },
   "devDependencies": {
-    "chai": "^4.2.0",
+    "chai": "^4.3.4",
     "chai-http": "^4.3.0",
-    "eslint": "^7.14.0",
-    "mocha": "^8.2.1",
+    "eslint": "^7.32.0",
+    "mocha": "^9.1.0",
     "nyc": "^15.1.0",
     "publish-please": "^5.5.2"
   },


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
Updated the version of the dependent packages.
And bugs have been fixed and messages have been fixed.
Regarding `publish_please`, we have added `.auditignore` because we are using the vulnerable `lodash` version.

### NOTES
At this time, `publish-please` does not have fixed following vulnerability about `lodash`.
https://npmjs.com/advisories/1673
Therefore, I added a `.auditignore` file for this issue.
Since `publish-please` is `devDependencies`, this fix allows to ignore the above audit issues.
