### PR TITLE
Enhanced the automatic registration for containers on Kubernetes

### DIFF
--- a/lib/k2hr3dkc.js
+++ b/lib/k2hr3dkc.js
@@ -4342,8 +4342,8 @@ function rawSetHostInfoValueFromKubernetesCuk(host_info, cuk, host_ip)
 
 	// check host ip address
 	var	keys = r3keys();
-	if(cuk_obj[keys.K8S_NODEIP_INCUK_KEY] != host_ip){
-		r3logger.elog('ip address(' + JSON.stringify(cuk_obj[keys.K8S_NODEIP_INCUK_KEY]) + ') in kubernetes cuk(' + JSON.stringify(cuk) + ') is not as same as requesting host ip(' + JSON.stringify(host_ip) + ').');
+	if(cuk_obj[keys.K8S_NODEIP_INCUK_KEY] != host_ip && cuk_obj[keys.K8S_PODIP_INCUK_KEY] != host_ip){
+		r3logger.elog('ip addresses(' + JSON.stringify(cuk_obj[keys.K8S_NODEIP_INCUK_KEY]) + ' or ' + JSON.stringify(cuk_obj[keys.K8S_PODIP_INCUK_KEY]) + ') in kubernetes cuk(' + JSON.stringify(cuk) + ') are not as same as requesting host ip(' + JSON.stringify(host_ip) + ').');
 		return false;
 	}
 


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
K2HR3 can cooperate with Kubernetes and enables automatic registration from Pod(Container) to ROLE member.
In this automatic registration from kubernetes, only the IP address of Node was confirmed, but the IP address of Pod(Conatiner) was also added.
This is a fix for the case where the K2HR3 is built in the same Kubernetes cluster as the registering pod.
