### PR TITLE
Changed the workaround for the publish-please audit error

### DIFF
--- a/.auditignore
+++ b/.auditignore
@@ -1,1 +1,0 @@
-https://npmjs.com/advisories/1673

--- a/.github/workflows/nodejs_helper.sh
+++ b/.github/workflows/nodejs_helper.sh
@@ -506,7 +506,7 @@ else
 	#
 	# Publish( or test it )
 	#
-	run_cmd npm run publish-please ${PUBLISH_PLEASE_OPT}
+	run_cmd npm run publish-please --production ${PUBLISH_PLEASE_OPT}
 
 	if [ ${PUBLISH_REQUESTED} -eq 1 -a ${IS_PUBLISHER} -eq 1 -a "X${NPM_TOKEN}" != "X" ]; then
 		echo "[INFO] ${PRGNAME} : Succeed publishing npm package, MUST CHECK NPM repository!!"


### PR DESCRIPTION
## Relevant Issue (if applicable)
#39 

## Details
The `publish-please` package currently has issues with audit again.
We used the `.auditignore` file for this, but this workaround is not effective.
The `publish-please` is a dev dependency and there is an error in the `npm audit` that `publish-please` itself calls.
So for the `npm audit` called by `publish-please`, pass the `--production` option to ignore the error in the dev dependency.
