### PR TITLE
Uses OpenID Connect Discovery to set jwks_uri

### DIFF
--- a/lib/k8soidc.js
+++ b/lib/k8soidc.js
@@ -39,7 +39,6 @@
 //		'k8soidc': {
 //			'audience':		'<client id for open id connect>',
 //			'issuer':		'<issue url for open id connect>',
-//			'jwks_uri':		'<jwks url for open id connect>',
 //			'usernamekey':	'<user name key name in token>',
 //			'k8sapi_url':	'<kubernetes api url>',
 //			'k8s_ca_path':	'<CA cert file path for kubernetes api url>',
@@ -56,10 +55,6 @@
 //	[issuer]
 //		Set the issuer URL of Open id connect. This key and value are
 //		required.
-//	[jwks_uri]
-//		Set the JWKS URL for Open id connect. This value is usually the
-//		issuer URL plus '/keys'(ex. '<issuer>/keys'). This key and value
-//		are required.
 //	[usernamekey]
 //		Specify the key name that is the Username set in the Token of
 //		Open id connect. If there is no key representing Username in
@@ -95,16 +90,19 @@ var	r3logger	= require('../lib/dbglogging');
 // decode oidc token libraries
 var	{ decode }					= require('jose/util/base64url');
 var	{ jwtVerify }				= require('jose/jwt/verify');
-var	{ decodeProtectedHeader }	= require('jose/util/decode_protected_header');
 var	{ createRemoteJWKSet }		= require('jose/jwks/remote');
 
 // kubernetes client api
 var	k8sclientapi				= require('@kubernetes/client-node');
 var	fs							= require('fs');
 
+// https library
+var https	= require('https');
+
 // const variables
 var	K8S_PUBLISHER_NAME			= 'K8SOIDC';
 var	K8S_REGION_NAME				= 'K8sCluster';
+var	OIDC_JWKS_URI_KEYNAME		= 'jwks_uri';
 
 //
 // Global variables from configuration file
@@ -127,7 +125,6 @@ var	k2hr3_k8s_sa_token	= null;
 	if(apiutil.isSafeEntity(oidc_config)){
 		oidc_audience	= oidc_config.audience;
 		oidc_issuer		= oidc_config.issuer;
-		oidc_jwks_uri	= oidc_config.jwks_uri;
 		oidc_username	= oidc_config.usernamekey;
 		k8s_api_url		= oidc_config.k8sapi_url;
 		k8s_ca_cert		= oidc_config.k8s_ca_path;
@@ -651,27 +648,70 @@ async function rawVerifyTokenAndGetUsername(token)
 		issuer:		oidc_issuer,
 		audience:	oidc_audience
 	};
-	var protectedHeader = decodeProtectedHeader(token);
-	var JWKS = createRemoteJWKSet(new URL(oidc_jwks_uri));
-	var { payload, protectedHeader } = await jwtVerify(token, JWKS, jwtParam).catch(function(err){		// eslint-disable-line no-unused-vars, no-redeclare
-		r3logger.elog(err.message);
-		throw err;
-	});
 
-	var	userName	= null;
-	if(apiutil.isSafeString(oidc_username)){
-		userName = payload[oidc_username];
-	}else{
-		if(apiutil.isSafeString(payload.sub)){
-			userName = payload.sub;
+	var myPromise = function(issuer_url, conf_key){
+		return new Promise(function(resolve, reject){
+			https.get(oidc_issuer + '/.well-known/openid-configuration', function(res){
+				if(res.statusCode !== 200){
+					res.resume();
+					reject('statusCode should be 200, not ', res.statusCode);
+				}
+				res.setEncoding('utf8');
+				let rawData = '';
+				res.on('data', function(chunk){ rawData += chunk; });
+				res.on('end', function(){
+					var parsedData = apiutil.parseJSON(rawData);
+					if(apiutil.isSafeEntity(parsedData[conf_key])){
+						resolve(parsedData[conf_key]);
+					}else{
+						var errorMsg = ('the ' + conf_key + ' key should exist, but no such a key');
+						r3logger.elog(errorMsg);
+						reject(errorMsg);
+					}
+				});
+			}).on('error', function(err){
+				r3logger.elog(err.message);
+				reject(err.message);
+			});
+		});
+	};
+
+	// 1. Calls async here.
+	async function asyncFunction(){
+		// 2. Calls await() here.
+		try{
+			oidc_jwks_uri = await myPromise(oidc_issuer, OIDC_JWKS_URI_KEYNAME);
+			if(!apiutil.isSafeString(oidc_jwks_uri)){
+				var	error = new Error('oidc_jwks_uri should be defined, but no oidc_jwks_uri.');
+				r3logger.elog(error.message);
+				throw error;
+			}
+		}catch(err){
+			r3logger.elog(err.message);
+			throw err;
 		}
+		var JWKS = createRemoteJWKSet(new URL(oidc_jwks_uri));
+		var { payload, protectedHeader } = await jwtVerify(token, JWKS, jwtParam).catch(function(err){		// eslint-disable-line no-unused-vars
+			r3logger.elog(err.message);
+			throw err;
+		});
+
+		var	userName	= null;
+		if(apiutil.isSafeString(oidc_username)){
+			userName = payload[oidc_username];
+		}else{
+			if(apiutil.isSafeString(payload.sub)){
+				userName = payload.sub;
+			}
+		}
+		if(!apiutil.isSafeString(userName)){
+			error = new Error('failed to verify token for getting user name.');
+			r3logger.elog(error.message);
+			throw error;
+		}
+		return userName;
 	}
-	if(!apiutil.isSafeString(userName)){
-		var	error = new Error('failed to verify token for getting user name.');
-		r3logger.elog(error.message);
-		throw error;
-	}
-	return userName;
+	return asyncFunction();
 }
 
 function rawGetUserUnscopedTokenK8s(token, callback)


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
Changed to create `jwks_uri` using `OpenID Connect Discovery`.
In the code before this PR, `jwks_uri` was used as a fixed value of `ISSUER_URL + / keys`, but there are some IaaS that are not `/keys`, and this PR supports them.

Due to the mechanism of `OpenID Connect Discovery`, `jwks_uri` will be obtained from `ISSUER_URL + .well-known/openid-configuration`.

see: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig