### PR TITLE
Updates ChangeLog and package.json for release 1.0.6

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+k2hr3-api (1.0.6) unstable; urgency=low
+
+  * Uses OpenID Connect Discovery to set jwks_uri - #53
+  * Changed the workaround for the publish-please audit error - #52
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Fri, 29 Oct 2021 13:33:54 +0900
+
 k2hr3-api (1.0.5) unstable; urgency=low
 
   * Updated dependencies - #49

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2hr3-api",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "dependencies": {
     "@kubernetes/client-node": "^0.15.1",
     "body-parser": "^1.19.0",
@@ -31,7 +31,7 @@
     "chai": "^4.3.4",
     "chai-http": "^4.3.0",
     "eslint": "^7.32.0",
-    "mocha": "^9.1.2",
+    "mocha": "^9.1.3",
     "nyc": "^15.1.0",
     "publish-please": "^5.5.2"
   },


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.5 to 1.0.6
- Uses OpenID Connect Discovery to set jwks_uri - #53
- Changed the workaround for the publish-please audit error - #52