### PR TITLE
Added config value as unscopedtoken expire for oidc

### DIFF
--- a/lib/k8soidc.js
+++ b/lib/k8soidc.js
@@ -37,12 +37,13 @@
 //
 //	{
 //		'k8soidc': {
-//			'audience':		'<client id for open id connect>',
-//			'issuer':		'<issue url for open id connect>',
-//			'usernamekey':	'<user name key name in token>',
-//			'k8sapi_url':	'<kubernetes api url>',
-//			'k8s_ca_path':	'<CA cert file path for kubernetes api url>',
-//			'k8s_sa_token':	'<Service account token for kubernetes>'
+//			'audience':			'<client id for open id connect>',
+//			'issuer':			'<issue url for open id connect>',
+//			'usernamekey':		'<user name key name in token>',
+//			'k8sapi_url':		'<kubernetes api url>',
+//			'k8s_ca_path':		'<CA cert file path for kubernetes api url>',
+//			'k8s_sa_token':		'<Service account token for kubernetes>'
+//			'unscopedtoken_exp':'<Expire limit for unscoped Token created from oidc>'
 //		}
 //	}
 //
@@ -75,6 +76,12 @@
 //		API. If you're running the K2HR3 API inside a Kubernetes pod,
 //		it's '/var/run/secrets/kubernetes.io/serviceaccount/token'.
 //		This key and value are required.
+//	[unscopedtoken_exp]
+//		Specifies the expiration date of the Unscoped token created by
+//		OIDC. This value is specified in seconds(s).
+//		If this value does not exist or is less than or equal to 0,
+//		the default value will be used. The default value is the same
+//		as the OIDC token expiration date.
 //
 //------------------------------------------------------------------------
 
@@ -115,6 +122,7 @@ var	oidc_username		= null;
 var	k8s_api_url			= null;
 var	k8s_ca_cert			= null;
 var	k2hr3_k8s_sa_token	= null;
+var	unscopedtoken_exp	= 0;			// Expire limit for unscoped Token created from oidc(default is 0 means as same as oidc limit)
 
 (function()
 {
@@ -123,12 +131,17 @@ var	k2hr3_k8s_sa_token	= null;
 	oidc_config	= apiConf.getOtherObject('k8soidc');
 
 	if(apiutil.isSafeEntity(oidc_config)){
-		oidc_audience	= oidc_config.audience;
-		oidc_issuer		= oidc_config.issuer;
-		oidc_username	= oidc_config.usernamekey;
-		k8s_api_url		= oidc_config.k8sapi_url;
-		k8s_ca_cert		= oidc_config.k8s_ca_path;
-		k2hr3_k8s_sa_token = fs.readFileSync(oidc_config.k8s_sa_token, 'utf8');
+		oidc_audience		= oidc_config.audience;
+		oidc_issuer			= oidc_config.issuer;
+		oidc_username		= oidc_config.usernamekey;
+		k8s_api_url			= oidc_config.k8sapi_url;
+		k8s_ca_cert			= oidc_config.k8s_ca_path;
+		k2hr3_k8s_sa_token	= fs.readFileSync(oidc_config.k8s_sa_token, 'utf8');
+
+		// unscopedtoken_exp must be number
+		if(apiutil.isSafeEntity(oidc_config.unscopedtoken_exp) && !isNaN(oidc_config.unscopedtoken_exp) && 0 < oidc_config.unscopedtoken_exp){
+			unscopedtoken_exp = oidc_config.unscopedtoken_exp;
+		}
 	}
 }());
 
@@ -186,8 +199,12 @@ function rawCreateUserTokenByK8sUser(user, user_id, tenant, expire_limit)
 	if(!apiutil.isSafeString(tenant)){
 		tenant = null;
 	}
-	if(!apiutil.isSafeEntity(expire_limit) || isNaN(expire_limit)){							// expire_limit must be number or null(undefined)
-		expire_limit = 24 * 60 * 60;														// default 24H
+	if(0 < unscopedtoken_exp){
+		expire_limit = unscopedtoken_exp;													// override expire limit by config
+	}else{
+		if(!apiutil.isSafeEntity(expire_limit) || isNaN(expire_limit) || expire_limit <= 0){
+			expire_limit = 24 * 60 * 60;													// default 24H
+		}
 	}
 
 	var	dkcobj			= k2hr3.getK2hdkc(true, false);										// use permanent object(need to clean)
@@ -799,7 +816,15 @@ function rawGetUserUnscopedTokenK8s(token, callback)
 
 		// core seed
 		var	user_id_uuid4	= apiutil.cvtNumberStringToUuid4(userid, 10);		// payload.sub is decimal string
-		var	expire_limit	= (new Date(payload['exp'] * 1000)).toISOString();	// payload['exp'] is a unixtime, convert to UTC ISO 8601
+		var	expire_limit;
+		if(apiutil.isSafeEntity(payload['exp']) && !isNaN(payload['exp'])){
+			expire_limit	= payload['exp'] - apiutil.getUnixtime();
+			if(expire_limit <= 0){
+				expire_limit= 24 * 60 * 60;										// default 24H
+			}
+		}else{
+			expire_limit	= 24 * 60 * 60;										// default 24H
+		}
 
 		// create token
 		var	resobj			= rawCreateUserTokenByK8sUser(lower_username, user_id_uuid4, null, expire_limit);


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
The expire limit(second) of the Unscoped Token issued at the time of OIDC authentication can be set as the config value.
Set this value(`unscopedtoken_exp`) to the number of seconds.
If not set or set to a value of 0(or less), the OIDC Token expiration date will be used as the default value. (This behavior is the default)
This value is primarily intended for use with k2hr3 systems that are automatically built by the user in systems like k2hdkc dbaas on k8s.

The following is a sample config sample:
```
{
    ...
    'k8soidc': {
        'audience':          'oidc_id',
        'issuer':            'oidc_issure',
        'k8sapi_url':        'https://k8s.....',
        'k8s_ca_path':       '/cacert',
        'k8s_sa_token':      'k8s_sa_token',
        'unscopedtoken_exp': 604800
    },
    ...
}
```