### PR TITLE
Updated dependency and Temporary audit avoidance

### DIFF
--- a/.github/workflows/nodejstypevars.sh
+++ b/.github/workflows/nodejstypevars.sh
@@ -171,6 +171,21 @@ SHELLCHECK_EXCEPT_PATHS="/node_modules/"
 #	run_publish			: publishing package				yes
 #	run_post_publish	: after publishing package			no
 #
+run_audit()
+{
+	# [NOTE]
+	# Added a temporary workaround(added --audit-level=high option).
+	# This is necessary due to missing fixes for request@2.88.2,
+	# which @kubernetes/client-node depends on.
+	# It will be remove this option once @kubernetes/client-node
+	# fix is done.
+	#
+	if ! /bin/sh -c "npm audit --audit-level=high"; then
+		PRNERR "Failed to run \"npm audit\"."
+		return 1
+	fi
+	return 0
+}
 
 #
 # Local variables:

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "dateformat": "^4.6.3",
     "debug": "~4.3.4",
     "express": "^4.18.2",
-    "jose": "^4.13.1",
-    "k2hdkc": "^1.0.4",
+    "jose": "^4.14.1",
+    "k2hdkc": "^1.0.5",
     "morgan": "~1.10.0",
     "rotating-file-stream": "^3.1.0"
   },
@@ -30,7 +30,7 @@
   "devDependencies": {
     "chai": "^4.3.7",
     "chai-http": "^4.3.0",
-    "eslint": "^8.35.0",
+    "eslint": "^8.39.0",
     "mocha": "^10.2.0",
     "nyc": "^15.1.0"
   },


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
- Updated package dependencies (versions)
- Avoid npm audit moderate error  
In Github Actions processing, added the `--audit-level=high` flag to temporarily bypass this error.  
This flag will be removed once the `@kubernetes/client-node` package has worked around this error.
