### PR TITLE
Added response object members in userToken GET API

### DIFF
--- a/lib/k2hr3tokens.js
+++ b/lib/k2hr3tokens.js
@@ -639,16 +639,19 @@ function rawRemoveScopedUserToken(token)
 // 
 // result		:	null or token information
 //					{
-//						role:		role name
-//						user:		user name
-//						hostname:	always null
-//						ip:			always null
-//						port:		always 0
-//						cuk:		always null
-//						extra:		always null
-//						tenant:		tenant name
-//						scoped:		role token is always scoped(true)
-//						region:		when user token, the creator region name of the token
+//						role:			role name
+//						user:			user name
+//						hostname:		always null
+//						ip:				always null
+//						port:			always 0
+//						cuk:			always null
+//						extra:			always null
+//						tenant:			tenant name
+//						display:		display alias name for tenant
+//						id:				tenant id string
+//						description:	description for tenant
+//						scoped:			role token is always scoped(true)
+//						region:			when user token, the creator region name of the token
 //					}
 // 
 function rawCheckUserToken(token)
@@ -1747,16 +1750,19 @@ function rawGetDirectRoleTokenInfo(dkcobj_permanent, tokens)
 // 
 // result		:	null or token information
 //					{
-//						role:		role name
-//						user:		null or user name
-//						hostname:	null or host name
-//						ip:			null or ip address
-//						port:		port number(if host is existed), 0 means any
-//						cuk:		cuk(allowed null)
-//						extra:		extra(allowed null)
-//						tenant:		tenant name
-//						scoped:		role token is always scoped(true)
-//						region:		role token is always null
+//						role:			role name
+//						user:			null or user name
+//						hostname:		null or host name
+//						ip:				null or ip address
+//						port:			port number(if host is existed), 0 means any
+//						cuk:			cuk(allowed null)
+//						extra:			extra(allowed null)
+//						tenant:			tenant name
+//						display:		display alias name for tenant
+//						id:				tenant id string
+//						description:	description for tenant
+//						scoped:			role token is always scoped(true)
+//						region:			role token is always null
 //					}
 // 
 function rawCheckRoleToken(token, ip, port, cuk, is_strict)
@@ -1827,6 +1833,12 @@ function rawCheckRoleToken(token, ip, port, cuk, is_strict)
 		dkcobj.clean();
 		return null;
 	}
+
+	// Get tenant information
+	var	tenant_keys		= r3keys(null, value.tenant);
+	value.display		= apiutil.getSafeString(dkcobj.getValue(tenant_keys.TENANT_DISP_KEY, null, true, null));
+	value.id			= apiutil.getSafeString(dkcobj.getValue(tenant_keys.TENANT_ID_KEY, null, true, null));
+	value.description	= apiutil.getSafeString(dkcobj.getValue(tenant_keys.TENANT_DESC_KEY, null, true, null));
 
 	// compare ip address, if they are specified and token is not created by user
 	if(!apiutil.isSafeString(value.user)){
@@ -1909,17 +1921,20 @@ function rawCheckRoleToken(token, ip, port, cuk, is_strict)
 	}
 
 	// make result
-	var	token_info		= {};
-	token_info.role		= value.role;
-	token_info.user		= value.user;
-	token_info.hostname	= value.hostname;													// hostname
-	token_info.ip		= value.ip;
-	token_info.port		= value.port;
-	token_info.cuk		= value.cuk;
-	token_info.extra	= value.extra;
-	token_info.tenant	= value.tenant;
-	token_info.scoped	= true;																// role token is always scoped
-	token_info.region	= null;
+	var	token_info			= {};
+	token_info.role			= value.role;
+	token_info.user			= value.user;
+	token_info.hostname		= value.hostname;												// hostname
+	token_info.ip			= value.ip;
+	token_info.port			= value.port;
+	token_info.cuk			= value.cuk;
+	token_info.extra		= value.extra;
+	token_info.tenant		= value.tenant;
+	token_info.display		= value.display;
+	token_info.id			= value.id;
+	token_info.description	= value.description;
+	token_info.scoped		= true;															// role token is always scoped
+	token_info.region		= null;
 
 	return token_info;
 }
@@ -2152,10 +2167,19 @@ function rawGetUserTenantByToken(token)
 		dkcobj.clean();
 		return null;
 	}
-	var	username	= apiutil.getSafeString(matches[1]);
-	var	tenantname	= apiutil.getSafeString(matches[2]);
-	if('' === tenantname){
-		tenantname	= null;
+	var	user_name		= apiutil.getSafeString(matches[1]);
+	var	tenant_name		= apiutil.getSafeString(matches[2]);
+	var	tenant_display	= null;
+	var	tenant_id		= null;
+	var	tenant_desc		= null;
+
+	if('' === tenant_name){
+		tenant_name		= null;
+	}else{
+		var	tenant_keys	= r3keys(user_name, tenant_name);
+		tenant_display	= apiutil.getSafeString(dkcobj.getValue(tenant_keys.TENANT_DISP_KEY, null, true, null));
+		tenant_id		= apiutil.getSafeString(dkcobj.getValue(tenant_keys.TENANT_ID_KEY, null, true, null));
+		tenant_desc		= apiutil.getSafeString(dkcobj.getValue(tenant_keys.TENANT_DESC_KEY, null, true, null));
 	}
 
 	// if token has seed, need to check seed
@@ -2168,20 +2192,21 @@ function rawGetUserTenantByToken(token)
 		//
 		//r3logger.dlog('token key(' + user_token_key + ') has seed.');
 
-		var	vres = osapi.verifyUserToken(username, tenantname, token, token_seed);
+		var	vres = osapi.verifyUserToken(user_name, tenant_name, token, token_seed);
 		if(!vres.result){
 			r3logger.elog('failed to verify token(' + token + ') with seed by ' + vres.message);
 			return null;
 		}
 	}
 
-	/* eslint-disable indent, no-mixed-spaces-and-tabs */
 	var	result	= {
-					user:	username,
-					tenant:	tenantname,
-					region:	region
-				  };
-	/* eslint-enable indent, no-mixed-spaces-and-tabs */
+		user:			user_name,
+		tenant:			tenant_name,
+		display:		tenant_display,
+		id:				tenant_id,
+		description:	tenant_desc,
+		region:			region
+	};
 
 	return result;
 }
@@ -2191,8 +2216,10 @@ function rawGetUserTenantByToken(token)
 //---------------------------------------------------------
 //	result		[
 //					{
-//						name:		"tenant name",				=> tenant name which is "key" in k2hdkc
-//						display:	"display tenant name"		=> display alias name for tenant
+//						name:			"tenant name",			=> tenant name which is "key" in k2hdkc
+//						display:		"display tenant name"	=> display alias name for tenant
+//						id:				"tenant id"				=> tenant id string
+//						description:	"tenant description"	=> description for tenant
 //					},
 //					...
 //				]
@@ -2245,13 +2272,15 @@ function rawGetTenantListByUserWithDkc(dkcobj_permanent, user)
 	var	tenant_list			= new Array(0);
 	for(cnt = 0; cnt < name_list.length; ++cnt){
 		var	tenant_keys		= r3keys(user, name_list[cnt]);
-		var	display_name	= dkcobj_permanent.getValue(tenant_keys.TENANT_DISP_KEY, null, true, null);
-		if(!apiutil.isSafeEntity(display_name)){
-			display_name = '';
-		}
+		var	tenant_display	= apiutil.getSafeString(dkcobj_permanent.getValue(tenant_keys.TENANT_DISP_KEY, null, true, null));
+		var	tenant_id		= apiutil.getSafeString(dkcobj_permanent.getValue(tenant_keys.TENANT_ID_KEY, null, true, null));
+		var	tenant_desc		= apiutil.getSafeString(dkcobj_permanent.getValue(tenant_keys.TENANT_DESC_KEY, null, true, null));
+
 		tenant_list.push({
 			name:			name_list[cnt],
-			display:		display_name
+			display:		tenant_display,
+			id:				tenant_id,
+			description:	tenant_desc
 		});
 	}
 
@@ -2260,8 +2289,10 @@ function rawGetTenantListByUserWithDkc(dkcobj_permanent, user)
 
 //	result		[
 //					{
-//						name:		"tenant name",				=> tenant name which is "key" in k2hdkc
-//						display:	"display tenant name"		=> display alias name for tenant
+//						name:			"tenant name",			=> tenant name which is "key" in k2hdkc
+//						display:		"display tenant name"	=> display alias name for tenant
+//						id:				"tenant id"				=> tenant id string
+//						description:	"tenant description"	=> description for tenant
 //					},
 //					...
 //				]
@@ -2429,15 +2460,18 @@ function rawCheckTenantInTenantList(tenants, tenant)
 //
 // token is following:
 //					{
-//						role:		role name
-//						user:		null or user name
-//						hostname:	null or host name
-//						ip:			null or host ip address
-//						port:		port number(if host is existed), 0 means any
-//						cuk:		cuk(allowed null)
-//						extra:		extra(allowed null)
-//						tenant:		tenant name
-//						scoped:		role token is always scoped(true)
+//						role:			role name
+//						user:			null or user name
+//						hostname:		null or host name
+//						ip:				null or host ip address
+//						port:			port number(if host is existed), 0 means any
+//						cuk:			cuk(allowed null)
+//						extra:			extra(allowed null)
+//						tenant:			tenant name
+//						display:		display alias name for tenant
+//						id:				tenant id string
+//						description:	description for tenant
+//						scoped:			role token is always scoped(true)
 //					}
 
 function rawCheckToken(req, is_scoped, is_user)

--- a/routes/userTokens.js
+++ b/routes/userTokens.js
@@ -50,13 +50,10 @@ function rawCommonGetUserToken(req, res, unscopedToken, otherToken, username, pa
 		// Get token from User Credentials
 		//
 		if(!apiutil.isSafeString(username)){
-			/* eslint-disable indent, no-mixed-spaces-and-tabs */
 			error = {
-						result: 	false,
-						message:	'Some parameter(user name or unscoped token) is wrong.'
-					};
-			/* eslint-enable indent, no-mixed-spaces-and-tabs */
-
+				result: 	false,
+				message:	'Some parameter(user name or unscoped token) is wrong.'
+			};
 			r3logger.elog(error.message);
 			resutil.errResponse(req, res, 400, error);				// 400: Bad Request
 			return;
@@ -65,27 +62,21 @@ function rawCommonGetUserToken(req, res, unscopedToken, otherToken, username, pa
 		r3token.getUserToken(_username, _passwd, _tenant, function(err, token)
 		{
 			if(null !== err){
-				/* eslint-disable indent, no-mixed-spaces-and-tabs */
 				var	error = {
-								result: 	false,
-								message:	'could not get scoped user token for user=' + _username + ', tenant=' + _tenant + ' by ' + err.message
-							};
-				/* eslint-enable indent, no-mixed-spaces-and-tabs */
-
+					result: 	false,
+					message:	'could not get scoped user token for user=' + _username + ', tenant=' + _tenant + ' by ' + err.message
+				};
 				r3logger.elog(error.message);
 				resutil.errResponse(_req, _res, 404, error);		// 404: Not Found
 				return;
 			}
 			r3logger.dlog('get user token jsonres = ' + JSON.stringify(token));
 
-			/* eslint-disable indent, no-mixed-spaces-and-tabs */
 			var	result = {	result:		true,
-							message:	'succeed',
-							scoped:		apiutil.isSafeString(_tenant),
-							token:		token
-						 };
-			/* eslint-enable indent, no-mixed-spaces-and-tabs */
-
+				message:	'succeed',
+				scoped:		apiutil.isSafeString(_tenant),
+				token:		token
+			};
 			_res.status(201);										// 201: Created
 			_res.send(JSON.stringify(result));
 		});
@@ -95,13 +86,10 @@ function rawCommonGetUserToken(req, res, unscopedToken, otherToken, username, pa
 		// Get Scoped token from Unscoped token
 		//
 		if(!apiutil.isSafeString(username)){
-			/* eslint-disable indent, no-mixed-spaces-and-tabs */
 			error = {
-						result: 	false,
-						message:	'Some parameter(user name or unscoped token) is wrong.'
-					};
-			/* eslint-enable indent, no-mixed-spaces-and-tabs */
-
+				result: 	false,
+				message:	'Some parameter(user name or unscoped token) is wrong.'
+			};
 			r3logger.elog(error.message);
 			resutil.errResponse(req, res, 400, error);				// 400: Bad Request
 			return;
@@ -110,27 +98,22 @@ function rawCommonGetUserToken(req, res, unscopedToken, otherToken, username, pa
 		r3token.getScopedUserToken(_unscopedToken, _username, _tenant, function(err, token)
 		{
 			if(null !== err){
-				/* eslint-disable indent, no-mixed-spaces-and-tabs */
 				var	error = {
-								result: 	false,
-								message:	'could not get scoped user token for user=' + _username + ', tenant=' + _tenant + ' by ' + err.message
-							};
-				/* eslint-enable indent, no-mixed-spaces-and-tabs */
-
+					result: 	false,
+					message:	'could not get scoped user token for user=' + _username + ', tenant=' + _tenant + ' by ' + err.message
+				};
 				r3logger.elog(error.message);
 				resutil.errResponse(_req, _res, 404, error);		// 404: Not Found
 				return;
 			}
 			r3logger.dlog('get user token jsonres = ' + JSON.stringify(token));
 
-			/* eslint-disable indent, no-mixed-spaces-and-tabs */
 			var	result = {
-							result:		true,
-							message:	'succeed',
-							scoped:		apiutil.isSafeString(_tenant),
-							token:		token
-						 };
-			/* eslint-enable indent, no-mixed-spaces-and-tabs */
+				result:		true,
+				message:	'succeed',
+				scoped:		apiutil.isSafeString(_tenant),
+				token:		token
+			};
 
 			_res.status(201);										// 201: Created
 			_res.send(JSON.stringify(result));
@@ -143,28 +126,22 @@ function rawCommonGetUserToken(req, res, unscopedToken, otherToken, username, pa
 		r3token.getUserTokenByToken(_otherToken, _tenant, function(err, token)
 		{
 			if(null !== err){
-				/* eslint-disable indent, no-mixed-spaces-and-tabs */
 				var	error = {
-								result: 	false,
-								message:	'could not get scoped user token for other token, tenant=' + _tenant + ' by ' + err.message
-							};
-				/* eslint-enable indent, no-mixed-spaces-and-tabs */
-
+					result: 	false,
+					message:	'could not get scoped user token for other token, tenant=' + _tenant + ' by ' + err.message
+				};
 				r3logger.elog(error.message);
 				resutil.errResponse(_req, _res, 404, error);		// 404: Not Found
 				return;
 			}
 			r3logger.dlog('get user token jsonres = ' + JSON.stringify(token));
 
-			/* eslint-disable indent, no-mixed-spaces-and-tabs */
 			var	result = {
-							result:		true,
-							message:	'succeed',
-							scoped:		apiutil.isSafeString(_tenant),
-							token:		token
-						 };
-			/* eslint-enable indent, no-mixed-spaces-and-tabs */
-
+				result:		true,
+				message:	'succeed',
+				scoped:		apiutil.isSafeString(_tenant),
+				token:		token
+			};
 			_res.status(201);										// 201: Created
 			_res.send(JSON.stringify(result));
 		});
@@ -188,13 +165,11 @@ function rawGetUnscopedUserToken(req)
 		!apiutil.isSafeString(resobj.token_info.user)			||
 		false !== resobj.token_info.scoped						)
 	{
-		/* eslint-disable indent, no-mixed-spaces-and-tabs */
 		return {
 			result: 	false,
 			status:		400,						// 400: Bad Request
 			message:	'could not get unscoped user token in request.'
 		};
-		/* eslint-enable indent, no-mixed-spaces-and-tabs */
 	}
 
 	return {
@@ -223,13 +198,10 @@ router.post('/', function(req, res, next)						// eslint-disable-line no-unused-
 	if(	!apiutil.isSafeEntity(req) ||
 		!apiutil.isSafeEntity(req.body) )
 	{
-		/* eslint-disable indent, no-mixed-spaces-and-tabs */
 		error = {
-					result: 	false,
-					message:	'POST body does not have auth key'
-				};
-		/* eslint-enable indent, no-mixed-spaces-and-tabs */
-
+			result: 	false,
+			message:	'POST body does not have auth key'
+		};
 		r3logger.elog(error.message);
 		resutil.errResponse(req, res, 400, error);				// 400: Bad Request
 		return;
@@ -260,13 +232,10 @@ router.post('/', function(req, res, next)						// eslint-disable-line no-unused-
 			// (1) case of unscoped token registered in k2hr3
 			//
 			if(!apiutil.isSafeEntity(req.body.auth) || !apiutil.isSafeString(req.body.auth.tenantName)){
-				/* eslint-disable indent, no-mixed-spaces-and-tabs */
 				error = {
-							result: 	false,
-							message:	'POST body does not have tenant name(or user credentials)'
-						};
-				/* eslint-enable indent, no-mixed-spaces-and-tabs */
-
+					result: 	false,
+					message:	'POST body does not have tenant name(or user credentials)'
+				};
 				r3logger.elog(error.message);
 				resutil.errResponse(req, res, 400, error);				// 400: Bad Request
 				return;
@@ -280,13 +249,10 @@ router.post('/', function(req, res, next)						// eslint-disable-line no-unused-
 			//
 			otherToken = r3token.getAuthTokenHeader(req, false);
 			if(!apiutil.isSafeString(otherToken)){
-				/* eslint-disable indent, no-mixed-spaces-and-tabs */
 				error = {
-							result: 	false,
-							message:	resobj.message
-						};
-				/* eslint-enable indent, no-mixed-spaces-and-tabs */
-
+					result: 	false,
+					message:	resobj.message
+				};
 				r3logger.elog(resobj.message);
 				resutil.errResponse(req, res, resobj.status, error);	// 40X
 				return;
@@ -320,13 +286,10 @@ router.put('/', function(req, res, next)						// eslint-disable-line no-unused-v
 	if(	!apiutil.isSafeEntity(req) ||
 		!apiutil.isSafeEntity(req.query) )
 	{
-		/* eslint-disable indent, no-mixed-spaces-and-tabs */
 		error = {
-					result: 	false,
-					message:	'PUT argument does not have any data'
-			 	};
-		/* eslint-enable indent, no-mixed-spaces-and-tabs */
-
+			result: 	false,
+			message:	'PUT argument does not have any data'
+		};
 		r3logger.elog(error.message);
 		resutil.errResponse(req, res, 400, error);				// 400: Bad Request
 		return;
@@ -357,13 +320,10 @@ router.put('/', function(req, res, next)						// eslint-disable-line no-unused-v
 			// (1) case of unscoped token registered in k2hr3
 			//
 			if(!apiutil.isSafeString(req.query.tenantname)){
-				/* eslint-disable indent, no-mixed-spaces-and-tabs */
 				error = {
-							result: 	false,
-							message:	'POST body does not have tenant name(or user credentials)'
-						};
-				/* eslint-enable indent, no-mixed-spaces-and-tabs */
-
+					result: 	false,
+					message:	'POST body does not have tenant name(or user credentials)'
+				};
 				r3logger.elog(error.message);
 				resutil.errResponse(req, res, 400, error);			// 400: Bad Request
 				return;
@@ -378,13 +338,10 @@ router.put('/', function(req, res, next)						// eslint-disable-line no-unused-v
 			//
 			otherToken = r3token.getAuthTokenHeader(req, false);
 			if(!apiutil.isSafeString(otherToken)){
-				/* eslint-disable indent, no-mixed-spaces-and-tabs */
 				error = {
-							result: 	false,
-							message:	resobj.message
-						};
-				/* eslint-enable indent, no-mixed-spaces-and-tabs */
-
+					result: 	false,
+					message:	resobj.message
+				};
 				r3logger.elog(resobj.message);
 				resutil.errResponse(req, res, resobj.status, error);	// 40X
 				return;
@@ -411,8 +368,10 @@ router.put('/', function(req, res, next)						// eslint-disable-line no-unused-v
 //							  user		=> user name
 //							  tenants	=>	[
 //												{
-//													name:		"tenant name"
-//													display:	"display name"
+//													name:			"tenant name"
+//													display:		"display name"
+//													id:				"tenant id"
+//													description:	"tenant description"
 //												},
 //												...
 //											]
@@ -453,21 +412,20 @@ router.get('/', function(req, res, next)						// eslint-disable-line no-unused-v
 	// build response body
 	if(token_info.scoped){
 		// scoped token
-		/* eslint-disable indent, no-mixed-spaces-and-tabs */
 		result = {
-					result:				true,
-					message:			'succeed',
-					scoped:				true,
-					user:				token_info.user,
-					tenants: [
-						{
-							name:		token_info.tenant,
-							display:	token_info.tenant			// [NOTE] this is not real display name.
-						}
-					]
-				 };
-		/* eslint-enable indent, no-mixed-spaces-and-tabs */
-
+			result:				true,
+			message:			'succeed',
+			scoped:				true,
+			user:				token_info.user,
+			tenants: [
+				{
+					name:			token_info.tenant,
+					display:		token_info.display,
+					id:				token_info.id,
+					description:	token_info.description
+				}
+			]
+		};
 		_res.status(200);										// 200: OK
 		_res.send(JSON.stringify(result));
 
@@ -476,13 +434,10 @@ router.get('/', function(req, res, next)						// eslint-disable-line no-unused-v
 		r3token.initializeTenantList(token_result.token, token_info.user, function(error, tenant_list)
 		{
 			if(null !== error){
-				/* eslint-disable indent, no-mixed-spaces-and-tabs */
 				var	result = {
-								result: 	false,
-								message:	'failed to get tenant list for user (' + token_info.user + ') by unscoped token(' + token_result.token + ')'
-						  	};
-				/* eslint-enable indent, no-mixed-spaces-and-tabs */
-
+					result: 	false,
+					message:	'failed to get tenant list for user (' + token_info.user + ') by unscoped token(' + token_result.token + ')'
+				};
 				r3logger.elog(result.message);
 				resutil.errResponse(_req, _res, 404, result);	// 404: Not Found
 				return;
@@ -491,26 +446,22 @@ router.get('/', function(req, res, next)						// eslint-disable-line no-unused-v
 			// reget tenant list
 			tenant_list = r3token.getTenantList(token_info.user);
 			if(null === tenant_list || apiutil.isEmptyArray(tenant_list)){
-				/* eslint-disable indent, no-mixed-spaces-and-tabs */
 				result = {
-							result: 	false,
-							message:	'token(' + token_result.token + ') for user (' + token_info.user + ') does not have any tenant.'
-						  };
-				/* eslint-enable indent, no-mixed-spaces-and-tabs */
-
+					result: 	false,
+					message:	'token(' + token_result.token + ') for user (' + token_info.user + ') does not have any tenant.'
+				};
 				r3logger.elog(result.message);
 				resutil.errResponse(_req, _res, 404, result);	// 404: Not Found
 				return;
 			}
 
-			/* eslint-disable indent, no-mixed-spaces-and-tabs */
-			result = {	result:		true,
-						message:	'succeed',
-						scoped:		false,
-						user:		token_info.user,
-						tenants:	tenant_list	};
-			/* eslint-enable indent, no-mixed-spaces-and-tabs */
-
+			result = {
+				result:		true,
+				message:	'succeed',
+				scoped:		false,
+				user:		token_info.user,
+				tenants:	tenant_list
+			};
 			_res.status(200);									// 200: OK
 			_res.send(JSON.stringify(result));
 		});

--- a/tests/auto_usertokens.js
+++ b/tests/auto_usertokens.js
@@ -431,11 +431,11 @@ describe('API : USER TOKEN', function(){				// eslint-disable-line no-undef
 				expect(res.body.scoped).to.be.a('boolean').to.be.false;
 				expect(res.body.user).to.be.a('string').to.equal('dummyuser');
 				expect(res.body.tenants).to.be.an.instanceof(Array).to.have.lengthOf(5);
-				expect(res.body.tenants[0]).to.deep.equal({name: 'tenant0', display: 'dummy_tenant_0'});
-				expect(res.body.tenants[1]).to.deep.equal({name: 'tenant1', display: 'dummy_tenant_1'});
-				expect(res.body.tenants[2]).to.deep.equal({name: 'tenant2', display: 'dummy_tenant_2'});
-				expect(res.body.tenants[3]).to.deep.equal({name: 'tenant3', display: 'dummy_tenant_3'});
-				expect(res.body.tenants[4]).to.deep.equal({name: 'tenant4', display: 'dummy_tenant_4'});
+				expect(res.body.tenants[0]).to.deep.equal({name: 'tenant0', id: '1000', description: 'dummy tenant no.0', display: 'dummy_tenant_0'});
+				expect(res.body.tenants[1]).to.deep.equal({name: 'tenant1', id: '1001', description: 'dummy tenant no.1', display: 'dummy_tenant_1'});
+				expect(res.body.tenants[2]).to.deep.equal({name: 'tenant2', id: '1002', description: 'dummy tenant no.2', display: 'dummy_tenant_2'});
+				expect(res.body.tenants[3]).to.deep.equal({name: 'tenant3', id: '1003', description: 'dummy tenant no.3', display: 'dummy_tenant_3'});
+				expect(res.body.tenants[4]).to.deep.equal({name: 'tenant4', id: '1004', description: 'dummy tenant no.4', display: 'dummy_tenant_4'});
 
 				done();
 			});
@@ -455,7 +455,7 @@ describe('API : USER TOKEN', function(){				// eslint-disable-line no-undef
 				expect(res.body.scoped).to.be.a('boolean').to.be.true;
 				expect(res.body.user).to.be.a('string').to.equal('dummyuser');
 				expect(res.body.tenants).to.be.an.instanceof(Array).to.have.lengthOf(1);
-				expect(res.body.tenants[0]).to.deep.equal({name: 'tenant0', display: 'tenant0'});
+				expect(res.body.tenants[0]).to.deep.equal({name: 'tenant0', id: '1000', description: 'dummy tenant no.0', display: 'dummy_tenant_0'});
 
 				done();
 			});


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
#100

### Details
Modified `GET` response of `TOKEN API`.
Added `description` and `id` (tenant ID) to `tenants` object members in the response.
This corresponds to `K2HR3 Local Tenant`.
Also removed unnecessary exception comments for `ESLint` in the fix file.