### PR TITLE
Fixed bugs about publishing packages and images

### DIFF
--- a/.github/workflows/nodejstypevars.sh
+++ b/.github/workflows/nodejstypevars.sh
@@ -84,7 +84,7 @@ elif [ "${CI_NODEJS_MAJOR_VERSION}" = "20" ]; then
 	INSTALL_PKG_LIST="git gcc g++ make k2hdkc-dev"
 	INSTALLER_BIN="apt-get"
 	INSTALL_QUIET_ARG="-qq"
-	IS_PUBLISHER=1
+	IS_PUBLISHER=0
 fi
 
 #---------------------------------------------------------------


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
There was a flaw in `nodejstypevars.sh`, which caused `Docker Image` publishing to fail, so I fixed it.
