### PR TITLE
Changed timeout value for checking openstack keystone

### DIFF
--- a/lib/openstackep.js
+++ b/lib/openstackep.js
@@ -421,7 +421,7 @@ function rawGetKeystoneEndpointsCallback(cbargs, err, epmap)
 //								  (default true)
 //		timeout					: specify the timeout required to check
 //								  each keystone endpoint.
-//								  (default 5000ms)
+//								  (default 30s)
 //		is_remake_keystone_ep	: if keystone endpoint is not registered,
 //								  it specifies whether to recreate it.
 //								  (default false)
@@ -437,7 +437,7 @@ function rawGetKeystoneEndpoint(callback, is_v3, is_test, timeout, is_remake_key
 {
 	var	error;
 	if(!apiutil.isSafeEntity(timeout) || isNaN(timeout)){
-		timeout = 5000;														// default 5s
+		timeout = 30000;													// default 30s
 	}
 	if('boolean' !== typeof is_test){
 		is_test = true;														// default true


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
Changed the timeout value when checking the OpenStack Keystone (V3 API) Endpoint on initial startup.
This is to avoid errors that occur when the startup environment takes a long time to check.
In the future, we will make it possible to specify this value in the configuration.
