### PR TITLE
Updated ChangeLog and package.json for release 1.0.37

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+k2hr3-api (1.0.37) unstable; urgency=low
+
+  * Changed timeout value for checking openstack keystone - #125
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Tue, 10 Dec 2024 10:22:08 +0900
+
 k2hr3-api (1.0.36) unstable; urgency=low
 
   * Updated k2hr3-init.sh.templ - #123

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2hr3-api",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "dependencies": {
     "@kubernetes/client-node": "^0.22.3",
     "body-parser": "^1.20.3",


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
#### Changes from 1.0.36 to 1.0.37
- Changed timeout value for checking openstack keystone - #125