### PR TITLE
Changed the PID file name to avoid collisions

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -36,8 +36,9 @@ LOCAL_HOSTNAME="$(hostname | tr -d '\n')"
 PID_FILE_BASEDIR="/var/run/antpickax"
 PID_FILE_TMPDIR="/tmp"
 
-MAINPROC_PID_BASENAME="${PRGNAME}.pid"
-WATCHPROC_PID_BASENAME="${PRGNAME}-watch.pid"
+PRGNAME_PREFIX=$(echo "${PRGNAME}" | sed -e 's#\.sh.*$##g')
+MAINPROC_PID_BASENAME="k2hr3pi-${PRGNAME_PREFIX}.pid"
+WATCHPROC_PID_BASENAME="k2hr3pi-${PRGNAME_PREFIX}-watch.pid"
 
 TARGET_PROGRAM=""
 MAIN_PROGRAM="bin/www"


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
The PID file name for run.sh to start the K2HR3 API is based on the script name.
However, if the K2HR3 APP is also started on the same host, this PID file name will clash.
To avoid this, a prefix has been added to the file name.