### PR TITLE
Allow k2hdkc installation scripts to run under newer npm versions

### DIFF
--- a/.github/workflows/imagetypevars.sh
+++ b/.github/workflows/imagetypevars.sh
@@ -84,6 +84,7 @@ elif [ "${CI_DOCKER_IMAGE_OSTYPE}" = "alpine" ]; then
 	PKG_INSTALL_BASE="g++ make nodejs npm python3 k2hdkc-dev bind-tools procps"
 	PKG_REPO_SETUP_NODEJS=""
 	NPM_INSTALL_BASE=""
+	NPM_INSTALL_ALLOW_SCRIPTS="--allow-scripts=k2hdkc"
 
 elif [ "${CI_DOCKER_IMAGE_OSTYPE}" = "ubuntu" ]; then
 	PKGMGR_NAME="apt-get"
@@ -103,6 +104,7 @@ elif [ "${CI_DOCKER_IMAGE_OSTYPE}" = "ubuntu" ]; then
 	"
 
 	NPM_INSTALL_BASE=""
+	NPM_INSTALL_ALLOW_SCRIPTS="--allow-scripts=k2hdkc"
 
 	#
 	# For installing tzdata with another package(ex. git)
@@ -200,12 +202,12 @@ set_custom_variables()
 	# Npm install packages
 	#
 	if [ -n "${NPM_INSTALL_BASE}" ]; then
-		NPM_INSTALL_BASE_COMMAND="${NPM_INSTALL_BASE}"
+		NPM_INSTALL_BASE_COMMAND="${NPM_INSTALL_BASE} ${NPM_INSTALL_ALLOW_SCRIPTS}"
 	else
 		#
 		# Set default package
 		#
-		NPM_INSTALL_BASE_COMMAND="npm install -g ${PACKAGE_NAME}${PACKAGE_VERSION_SUFFIX}"
+		NPM_INSTALL_BASE_COMMAND="npm install -g ${PACKAGE_NAME}${PACKAGE_VERSION_SUFFIX} ${NPM_INSTALL_ALLOW_SCRIPTS}"
 	fi
 	return 0
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,12 @@
     "debug": "~4.4.3",
     "express": "^5.2.1",
     "jose": "^6.2.3",
-    "k2hdkc": "^2.0.5",
+    "k2hdkc": "^2.0.6",
     "morgan": "~1.11.0",
     "rotating-file-stream": "^3.2.9"
+  },
+  "allowScripts": {
+    "k2hdkc": true
   },
   "directories": {
     "config": "config",
@@ -35,7 +38,7 @@
     "k2hr3-watcher": "dist/src/bin/watcher.js"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3.3.5",
+    "@eslint/eslintrc": "^3.3.6",
     "@eslint/js": "^10.0.1",
     "@types/body-parser": "^1.19.6",
     "@types/chai": "^5.2.3",
@@ -46,12 +49,12 @@
     "@types/express": "^5.0.6",
     "@types/mocha": "^10.0.10",
     "@types/morgan": "^1.9.10",
-    "@types/node": "^26.1.0",
+    "@types/node": "^26.1.1",
     "@typescript-eslint/eslint-plugin": "^8.62.1",
     "@typescript-eslint/parser": "^8.62.1",
     "chai": "^6.2.2",
     "chai-http": "^5.1.2",
-    "eslint": "^10.6.0",
+    "eslint": "^10.7.0",
     "globals": "^17.7.0",
     "mocha": "^11.7.6",
     "nyc": "^18.0.0",

--- a/src/lib/k2hr3tokens.ts
+++ b/src/lib/k2hr3tokens.ts
@@ -614,7 +614,7 @@ const rawGetUserToken = (
 	}
 
 	const	_tenant	= apiutil.getSafeString(tenant).toLowerCase();
-	let		_user	= user;
+	const	_user	= user;
 	const	_passwd	= apiutil.getSafeString(passwd);
 
 	// get unscoped token
@@ -627,7 +627,7 @@ const rawGetUserToken = (
 		}
 
 		// save to local val
-		_user					= jsonres.user;								// over write
+		//const _cur_user		= jsonres.user;
 		const _userid			= jsonres.userid;
 		const _username			= jsonres.user;
 		const _unscopedtoken	= jsonres.token;


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
In `npm v11.0.0` and later, measures have been implemented to address "sub-dependency chain" vulnerabilities associated with package installation; specifically, scripts that previously ran during installation are now prevented from executing.
This product utilizes the `k2hdkc nodejs addon`, which triggers a script during the `install` phase to either build the package or download a binary from `GitHub Assets` consequently, this process would fail to function under the new `npm` behavior.

To resolve this, we have modified `package.json` and the (automatically generated) `Dockerfile` to explicitly allow script execution for the `k2hdkc` package installation.

I found another bug and have fixed it.